### PR TITLE
Make MonitoringUI API URLs relative

### DIFF
--- a/Docker/KlusterKiteMonitoring/klusterkite-web/.env
+++ b/Docker/KlusterKiteMonitoring/klusterkite-web/.env
@@ -1,2 +1,2 @@
-REACT_APP_GRAPHQL_URL=http://localhost/api/1.x/graphQL
-REACT_APP_AUTH_URL=http://localhost/api/1.x/security/token
+REACT_APP_GRAPHQL_URL=/api/1.x/graphQL
+REACT_APP_AUTH_URL=/api/1.x/security/token

--- a/Docker/KlusterKiteMonitoring/klusterkite-web/.env-local
+++ b/Docker/KlusterKiteMonitoring/klusterkite-web/.env-local
@@ -1,2 +1,2 @@
-REACT_APP_GRAPHQL_URL=http://localhost/api/1.x/graphQL
-REACT_APP_AUTH_URL=http://localhost/api/1.x/security/token
+REACT_APP_GRAPHQL_URL=/api/1.x/graphQL
+REACT_APP_AUTH_URL=/api/1.x/security/token

--- a/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/GraphQL/GraphQLPage.js
+++ b/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/GraphQL/GraphQLPage.js
@@ -8,7 +8,7 @@ import './style.css';
 
 export default class GraphQLPage extends React.Component {
   graphQLFetcher(graphQLParams) {
-    const url = process.env.REACT_APP_GRAPHQL_URL || 'http://localhost/api/1.x/graphQL';
+    const url = process.env.REACT_APP_GRAPHQL_URL || '/api/1.x/graphQL';
 
     return fetch(url, {
       method: 'post',


### PR DESCRIPTION
## Summary
- The `.env` / `.env-local` files and the GraphQL page fallback hardcoded `http://localhost/api/...`, which got baked into the React bundle at build time and broke the UI whenever the cluster entrypoint was exposed on a port other than 80 (e.g. 8080).
- The monitoring container's nginx already proxies `/api/` to the `entry` upstream (`Docker/KlusterKiteMonitoring/klusterkite-web/.nginx.conf`), so relative URLs resolve correctly regardless of host or port.
- `src/utils/store.js` was already relative; this PR aligns the remaining call sites (`GraphQLPage`, `AuthPage`, `auth-middleware`) by fixing the env vars and the lone hardcoded fallback.

## Test plan
- [ ] Rebuild the `klusterkite-web` bundle (`npm run build`) and the `klusterkitemonitoring` Docker image.
- [ ] Verify the bundled `build/static/js/main.*.js` no longer contains `localhost/api`.
- [ ] Bring up the cluster with the entrypoint exposed on port 8080 and confirm login, GraphQL queries, and the GraphiQL page all work from the MonitoringUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)