### PR TITLE
Retry pending WebDescriptionRequests; stop forcing Serilog SelfLog

### DIFF
--- a/KlusterKite.Log/KlusterKite.Log.ElasticSearch/Configurator.cs
+++ b/KlusterKite.Log/KlusterKite.Log.ElasticSearch/Configurator.cs
@@ -37,7 +37,6 @@ namespace KlusterKite.Log.ElasticSearch
         /// <returns>Updated configuration</returns>
         public LoggerConfiguration Configure(LoggerConfiguration configuration, Config config)
         {
-            SelfLog.Enable(Console.WriteLine);
             var loggerConfiguration = configuration;
             loggerConfiguration = this.ConfigureStandardLog(loggerConfiguration, config);
             loggerConfiguration = this.ConfigureSecurityLog(loggerConfiguration, config);

--- a/KlusterKite.Web/KlusterKite.Web.NginxConfigurator/NginxConfiguratorActor.cs
+++ b/KlusterKite.Web/KlusterKite.Web.NginxConfigurator/NginxConfiguratorActor.cs
@@ -45,6 +45,9 @@ namespace KlusterKite.Web.NginxConfigurator
         /// <summary>
         /// Initializes a new instance of the <see cref="NginxConfiguratorActor"/> class.
         /// </summary>
+        /// <summary>Sent to self on a schedule to retry pending Web nodes that haven't responded yet.</summary>
+        private sealed class RetryPendingNodes { public static readonly RetryPendingNodes Instance = new RetryPendingNodes(); }
+
         public NginxConfiguratorActor()
         {
             this.configPath = Context.System.Settings.Config.GetString("KlusterKite.Web.Nginx.PathToConfig");
@@ -66,6 +69,18 @@ namespace KlusterKite.Web.NginxConfigurator
                 m => this.OnWebNodeDown(m.Member.Address));
 
             this.Receive<WebDescriptionResponse>(r => this.OnNewNodeDescription(r));
+
+            // Retry any Web nodes that joined but whose WebDescriptorActor hadn't started yet
+            // when we first sent the request. On slow/low-CPU machines the WebDescriptorActor
+            // can take several seconds longer to initialize than the MemberUp gossip takes to
+            // propagate, so the first request dead-letters. Retry every 15 s until answered.
+            this.Receive<RetryPendingNodes>(_ => this.RetryPending());
+            Context.System.Scheduler.ScheduleTellRepeatedly(
+                TimeSpan.FromSeconds(15),
+                TimeSpan.FromSeconds(15),
+                this.Self,
+                RetryPendingNodes.Instance,
+                this.Self);
         }
 
         /// <summary>
@@ -272,6 +287,21 @@ namespace KlusterKite.Web.NginxConfigurator
             this.Configuration.Flush();
             this.NodePublishUrls.Remove(nodeAddress);
             this.WriteConfiguration();
+        }
+
+        /// <summary>
+        /// Re-sends WebDescriptionRequest to any known Web nodes that haven't replied yet.
+        /// </summary>
+        private void RetryPending()
+        {
+            foreach (var address in this.KnownActiveNodes)
+            {
+                if (!this.NodePublishUrls.ContainsKey(address))
+                {
+                    Context.GetLogger().Info("{Type}: retrying WebDescriptionRequest to {Address}", this.GetType().Name, address);
+                    Context.System.GetWebDescriptor(address).Tell(new WebDescriptionRequest(), this.Self);
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Two unrelated runtime bugs surfaced when bringing up a cluster on a low-CPU VM. Both are general issues, not Linux-specific.

### `NginxConfiguratorActor` — first `WebDescriptionRequest` can dead-letter

When a Web node joins, `OnWebNodeUp` sends it a `WebDescriptionRequest` immediately on `MemberUp`. On slow / low-core machines the remote `WebDescriptorActor` finishes initialization several seconds after `MemberUp` gossip propagates, so the first request lands in dead letters and is never retried. The cluster's Nginx config then never picks up that node.

Fix: schedule a 15 s repeating self-message that re-sends `WebDescriptionRequest` to any `KnownActiveNode` that doesn't yet have a `NodePublishUrls` entry. Once the response arrives the node is fully registered and subsequent ticks no-op for it.

### `KlusterKite.Log.ElasticSearch.Configurator` — unconditional `SelfLog.Enable(Console.WriteLine)`

`Configure` calls `SelfLog.Enable(Console.WriteLine)` on every invocation. When Elasticsearch is unreachable this produces continuous connection-failure noise on stdout that drowns out the actual application logs. Callers that need Serilog SelfLog should enable it explicitly; the ES configurator shouldn't do it on their behalf.

## Test plan
- [ ] Bring a cluster up on a 2-CPU host; confirm the first Web node it sees gets registered in the Nginx config without a manual restart
- [ ] Run with Elasticsearch off; confirm stdout no longer fills with `HttpClient.Send`/connection-refused noise from Serilog SelfLog