### PR TITLE
GraphQL resolvers: node-field collision, V2 search, nullable enums

### DIFF
--- a/Docker/KlusterKiteMonitoring/klusterkite-web/schema.json
+++ b/Docker/KlusterKiteMonitoring/klusterkite-web/schema.json
@@ -10,80 +10,22 @@
       "subscriptionType": null,
       "types": [
         {
-          "kind": "SCALAR",
-          "name": "String",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Boolean",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Float",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Int",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "ID",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Date",
-          "description": "The `Date` scalar type represents a timestamp provided in UTC. `Date` expects timestamps to be formatted in accordance with the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Decimal",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "OBJECT",
           "name": "__Schema",
           "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
           "fields": [
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "types",
               "description": "A list of all types supported by this server.",
@@ -175,6 +117,16 @@
           ],
           "inputFields": null,
           "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -356,6 +308,18 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "isOneOf",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -379,43 +343,43 @@
             },
             {
               "name": "OBJECT",
-              "description": "Indicates this type is an object.  `fields` and `possibletypes` are valid fields.",
+              "description": "Indicates this type is an object. `fields` and `possibleTypes` are valid fields.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "INTERFACE",
-              "description": "Indicates this type is an interface.  `fields` and `possibleTypes` are valid fields.",
+              "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "UNION",
-              "description": "Indicates this type is a union.  `possibleTypes` is a valid field.",
+              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ENUM",
-              "description": "Indicates this type is an num.  `enumValues` is a valid field.",
+              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "INPUT_OBJECT",
-              "description": "Indicates this type is an input object.  `inputFields` is a valid field.",
+              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "LIST",
-              "description": "Indicates this type is a list.  `ofType` is a valid field.",
+              "description": "Indicates this type is a list. `ofType` is a valid field.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "NON_NULL",
-              "description": "Indicates this type is a non-null.  `ofType` is a valid field.",
+              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -597,6 +561,16 @@
           "possibleTypes": null
         },
         {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "OBJECT",
           "name": "__EnumValue",
           "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
@@ -638,7 +612,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "Boolean",
                   "ofType": null
                 }
               },
@@ -826,7 +800,7 @@
             },
             {
               "name": "FIELD",
-              "description": "Location ajdacent to a field.",
+              "description": "Location adjacent to a field.",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -845,6 +819,12 @@
             {
               "name": "INLINE_FRAGMENT",
               "description": "Location adjacent to an inline fragment.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "VARIABLE_DEFINITION",
+              "description": "Location adjacent to a variable definition.",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -874,7 +854,7 @@
             },
             {
               "name": "ARGUMENT_DEFINITION",
-              "description": "Location adjacent to an argument defintion.",
+              "description": "Location adjacent to an argument definition.",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -904,7 +884,7 @@
             },
             {
               "name": "INPUT_OBJECT",
-              "description": "Location adjacent to an input object type defintion.",
+              "description": "Location adjacent to an input object type definition.",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -948,7 +928,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -957,6 +937,16 @@
               "ofType": null
             }
           ]
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ID",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
         },
         {
           "kind": "INTERFACE",
@@ -992,6 +982,16 @@
               "description": "Gets the list of nodes",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -1002,11 +1002,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteMonitoring_Pair_System_String_Node__Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -1026,21 +1026,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteMonitoring_Pair_System_String_Node__Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -1059,6 +1049,16 @@
               "description": "Gets the  nodes flat list",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -1069,11 +1069,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteMonitoring_Node_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -1093,21 +1093,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteMonitoring_Node_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -1135,7 +1125,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -1144,6 +1134,16 @@
               "ofType": null
             }
           ]
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
         },
         {
           "kind": "INTERFACE",
@@ -1180,7 +1180,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -1221,7 +1221,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -1274,7 +1274,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -1402,6 +1402,16 @@
               "description": "the actor's children",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -1412,11 +1422,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteMonitoring_Node_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -1436,21 +1446,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteMonitoring_Node_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -1490,7 +1490,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -1535,7 +1535,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -1576,7 +1576,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -1585,137 +1585,6 @@
               "ofType": null
             }
           ]
-        },
-        {
-          "kind": "ENUM",
-          "name": "KlusterKiteMonitoring_Node_Sort",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "actorType_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "actorType_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "currentMessage_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "currentMessage_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "dispatcherId_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "dispatcherId_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "dispatcherType_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "dispatcherType_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "maxQueueSize_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "maxQueueSize_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "queueSize_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "queueSize_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "queueSizeSum_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "queueSizeSum_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "address_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "address_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "parentAddress_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "parentAddress_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
         },
         {
           "kind": "INPUT_OBJECT",
@@ -1845,7 +1714,7 @@
             },
             {
               "name": "actorType_l",
-              "description": "actorType lowercased equals the parameter, actorType: the actor's type",
+              "description": "actorType lower-cased equals the parameter, actorType: the actor's type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -1855,7 +1724,7 @@
             },
             {
               "name": "actorType_l_not",
-              "description": "actorType lowercased doesn't equal the parameter, actorType: the actor's type",
+              "description": "actorType lower-cased doesn't equal the parameter, actorType: the actor's type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -1865,7 +1734,7 @@
             },
             {
               "name": "actorType_l_in",
-              "description": "actorType lowercased is a substring of the parameter, actorType: the actor's type",
+              "description": "actorType lower-cased is a substring of the parameter, actorType: the actor's type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -1875,7 +1744,7 @@
             },
             {
               "name": "actorType_l_not_in",
-              "description": "actorType lowercased is not a substring of the parameter, actorType: the actor's type",
+              "description": "actorType lower-cased is not a substring of the parameter, actorType: the actor's type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -1885,7 +1754,7 @@
             },
             {
               "name": "actorType_l_contains",
-              "description": "actorType lowercased contains the parameter as substring, actorType: the actor's type",
+              "description": "actorType lower-cased contains the parameter as substring, actorType: the actor's type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -1895,7 +1764,7 @@
             },
             {
               "name": "actorType_l_not_contains",
-              "description": "actorType lowercased doesn't contain the parameter as substring, actorType: the actor's type",
+              "description": "actorType lower-cased doesn't contain the parameter as substring, actorType: the actor's type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -1905,7 +1774,7 @@
             },
             {
               "name": "actorType_l_starts_with",
-              "description": "actorType lowercased starts with the parameter value, actorType: the actor's type",
+              "description": "actorType lower-cased starts with the parameter value, actorType: the actor's type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -1915,7 +1784,7 @@
             },
             {
               "name": "actorType_l_not_starts_with",
-              "description": "actorType lowercased doesn't start with the parameter value, actorType: the actor's type",
+              "description": "actorType lower-cased doesn't start with the parameter value, actorType: the actor's type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -1925,7 +1794,7 @@
             },
             {
               "name": "actorType_l_ends_with",
-              "description": "actorType lowercased ends with the parameter value, actorType: the actor's type",
+              "description": "actorType lower-cased ends with the parameter value, actorType: the actor's type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -1935,7 +1804,7 @@
             },
             {
               "name": "actorType_l_not_ends_with",
-              "description": "actorType lowercased doesn't end with the parameter value, actorType: the actor's type",
+              "description": "actorType lower-cased doesn't end with the parameter value, actorType: the actor's type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2045,7 +1914,7 @@
             },
             {
               "name": "currentMessage_l",
-              "description": "currentMessage lowercased equals the parameter, currentMessage: the actor's last message",
+              "description": "currentMessage lower-cased equals the parameter, currentMessage: the actor's last message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2055,7 +1924,7 @@
             },
             {
               "name": "currentMessage_l_not",
-              "description": "currentMessage lowercased doesn't equal the parameter, currentMessage: the actor's last message",
+              "description": "currentMessage lower-cased doesn't equal the parameter, currentMessage: the actor's last message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2065,7 +1934,7 @@
             },
             {
               "name": "currentMessage_l_in",
-              "description": "currentMessage lowercased is a substring of the parameter, currentMessage: the actor's last message",
+              "description": "currentMessage lower-cased is a substring of the parameter, currentMessage: the actor's last message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2075,7 +1944,7 @@
             },
             {
               "name": "currentMessage_l_not_in",
-              "description": "currentMessage lowercased is not a substring of the parameter, currentMessage: the actor's last message",
+              "description": "currentMessage lower-cased is not a substring of the parameter, currentMessage: the actor's last message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2085,7 +1954,7 @@
             },
             {
               "name": "currentMessage_l_contains",
-              "description": "currentMessage lowercased contains the parameter as substring, currentMessage: the actor's last message",
+              "description": "currentMessage lower-cased contains the parameter as substring, currentMessage: the actor's last message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2095,7 +1964,7 @@
             },
             {
               "name": "currentMessage_l_not_contains",
-              "description": "currentMessage lowercased doesn't contain the parameter as substring, currentMessage: the actor's last message",
+              "description": "currentMessage lower-cased doesn't contain the parameter as substring, currentMessage: the actor's last message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2105,7 +1974,7 @@
             },
             {
               "name": "currentMessage_l_starts_with",
-              "description": "currentMessage lowercased starts with the parameter value, currentMessage: the actor's last message",
+              "description": "currentMessage lower-cased starts with the parameter value, currentMessage: the actor's last message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2115,7 +1984,7 @@
             },
             {
               "name": "currentMessage_l_not_starts_with",
-              "description": "currentMessage lowercased doesn't start with the parameter value, currentMessage: the actor's last message",
+              "description": "currentMessage lower-cased doesn't start with the parameter value, currentMessage: the actor's last message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2125,7 +1994,7 @@
             },
             {
               "name": "currentMessage_l_ends_with",
-              "description": "currentMessage lowercased ends with the parameter value, currentMessage: the actor's last message",
+              "description": "currentMessage lower-cased ends with the parameter value, currentMessage: the actor's last message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2135,7 +2004,7 @@
             },
             {
               "name": "currentMessage_l_not_ends_with",
-              "description": "currentMessage lowercased doesn't end with the parameter value, currentMessage: the actor's last message",
+              "description": "currentMessage lower-cased doesn't end with the parameter value, currentMessage: the actor's last message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2245,7 +2114,7 @@
             },
             {
               "name": "dispatcherId_l",
-              "description": "dispatcherId lowercased equals the parameter, dispatcherId: the actor's dispatcher id",
+              "description": "dispatcherId lower-cased equals the parameter, dispatcherId: the actor's dispatcher id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2255,7 +2124,7 @@
             },
             {
               "name": "dispatcherId_l_not",
-              "description": "dispatcherId lowercased doesn't equal the parameter, dispatcherId: the actor's dispatcher id",
+              "description": "dispatcherId lower-cased doesn't equal the parameter, dispatcherId: the actor's dispatcher id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2265,7 +2134,7 @@
             },
             {
               "name": "dispatcherId_l_in",
-              "description": "dispatcherId lowercased is a substring of the parameter, dispatcherId: the actor's dispatcher id",
+              "description": "dispatcherId lower-cased is a substring of the parameter, dispatcherId: the actor's dispatcher id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2275,7 +2144,7 @@
             },
             {
               "name": "dispatcherId_l_not_in",
-              "description": "dispatcherId lowercased is not a substring of the parameter, dispatcherId: the actor's dispatcher id",
+              "description": "dispatcherId lower-cased is not a substring of the parameter, dispatcherId: the actor's dispatcher id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2285,7 +2154,7 @@
             },
             {
               "name": "dispatcherId_l_contains",
-              "description": "dispatcherId lowercased contains the parameter as substring, dispatcherId: the actor's dispatcher id",
+              "description": "dispatcherId lower-cased contains the parameter as substring, dispatcherId: the actor's dispatcher id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2295,7 +2164,7 @@
             },
             {
               "name": "dispatcherId_l_not_contains",
-              "description": "dispatcherId lowercased doesn't contain the parameter as substring, dispatcherId: the actor's dispatcher id",
+              "description": "dispatcherId lower-cased doesn't contain the parameter as substring, dispatcherId: the actor's dispatcher id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2305,7 +2174,7 @@
             },
             {
               "name": "dispatcherId_l_starts_with",
-              "description": "dispatcherId lowercased starts with the parameter value, dispatcherId: the actor's dispatcher id",
+              "description": "dispatcherId lower-cased starts with the parameter value, dispatcherId: the actor's dispatcher id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2315,7 +2184,7 @@
             },
             {
               "name": "dispatcherId_l_not_starts_with",
-              "description": "dispatcherId lowercased doesn't start with the parameter value, dispatcherId: the actor's dispatcher id",
+              "description": "dispatcherId lower-cased doesn't start with the parameter value, dispatcherId: the actor's dispatcher id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2325,7 +2194,7 @@
             },
             {
               "name": "dispatcherId_l_ends_with",
-              "description": "dispatcherId lowercased ends with the parameter value, dispatcherId: the actor's dispatcher id",
+              "description": "dispatcherId lower-cased ends with the parameter value, dispatcherId: the actor's dispatcher id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2335,7 +2204,7 @@
             },
             {
               "name": "dispatcherId_l_not_ends_with",
-              "description": "dispatcherId lowercased doesn't end with the parameter value, dispatcherId: the actor's dispatcher id",
+              "description": "dispatcherId lower-cased doesn't end with the parameter value, dispatcherId: the actor's dispatcher id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2445,7 +2314,7 @@
             },
             {
               "name": "dispatcherType_l",
-              "description": "dispatcherType lowercased equals the parameter, dispatcherType: the actor's dispatcher type",
+              "description": "dispatcherType lower-cased equals the parameter, dispatcherType: the actor's dispatcher type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2455,7 +2324,7 @@
             },
             {
               "name": "dispatcherType_l_not",
-              "description": "dispatcherType lowercased doesn't equal the parameter, dispatcherType: the actor's dispatcher type",
+              "description": "dispatcherType lower-cased doesn't equal the parameter, dispatcherType: the actor's dispatcher type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2465,7 +2334,7 @@
             },
             {
               "name": "dispatcherType_l_in",
-              "description": "dispatcherType lowercased is a substring of the parameter, dispatcherType: the actor's dispatcher type",
+              "description": "dispatcherType lower-cased is a substring of the parameter, dispatcherType: the actor's dispatcher type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2475,7 +2344,7 @@
             },
             {
               "name": "dispatcherType_l_not_in",
-              "description": "dispatcherType lowercased is not a substring of the parameter, dispatcherType: the actor's dispatcher type",
+              "description": "dispatcherType lower-cased is not a substring of the parameter, dispatcherType: the actor's dispatcher type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2485,7 +2354,7 @@
             },
             {
               "name": "dispatcherType_l_contains",
-              "description": "dispatcherType lowercased contains the parameter as substring, dispatcherType: the actor's dispatcher type",
+              "description": "dispatcherType lower-cased contains the parameter as substring, dispatcherType: the actor's dispatcher type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2495,7 +2364,7 @@
             },
             {
               "name": "dispatcherType_l_not_contains",
-              "description": "dispatcherType lowercased doesn't contain the parameter as substring, dispatcherType: the actor's dispatcher type",
+              "description": "dispatcherType lower-cased doesn't contain the parameter as substring, dispatcherType: the actor's dispatcher type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2505,7 +2374,7 @@
             },
             {
               "name": "dispatcherType_l_starts_with",
-              "description": "dispatcherType lowercased starts with the parameter value, dispatcherType: the actor's dispatcher type",
+              "description": "dispatcherType lower-cased starts with the parameter value, dispatcherType: the actor's dispatcher type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2515,7 +2384,7 @@
             },
             {
               "name": "dispatcherType_l_not_starts_with",
-              "description": "dispatcherType lowercased doesn't start with the parameter value, dispatcherType: the actor's dispatcher type",
+              "description": "dispatcherType lower-cased doesn't start with the parameter value, dispatcherType: the actor's dispatcher type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2525,7 +2394,7 @@
             },
             {
               "name": "dispatcherType_l_ends_with",
-              "description": "dispatcherType lowercased ends with the parameter value, dispatcherType: the actor's dispatcher type",
+              "description": "dispatcherType lower-cased ends with the parameter value, dispatcherType: the actor's dispatcher type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2535,7 +2404,7 @@
             },
             {
               "name": "dispatcherType_l_not_ends_with",
-              "description": "dispatcherType lowercased doesn't end with the parameter value, dispatcherType: the actor's dispatcher type",
+              "description": "dispatcherType lower-cased doesn't end with the parameter value, dispatcherType: the actor's dispatcher type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2705,7 +2574,7 @@
             },
             {
               "name": "name_l",
-              "description": "name lowercased equals the parameter, name: the actor's name",
+              "description": "name lower-cased equals the parameter, name: the actor's name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2715,7 +2584,7 @@
             },
             {
               "name": "name_l_not",
-              "description": "name lowercased doesn't equal the parameter, name: the actor's name",
+              "description": "name lower-cased doesn't equal the parameter, name: the actor's name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2725,7 +2594,7 @@
             },
             {
               "name": "name_l_in",
-              "description": "name lowercased is a substring of the parameter, name: the actor's name",
+              "description": "name lower-cased is a substring of the parameter, name: the actor's name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2735,7 +2604,7 @@
             },
             {
               "name": "name_l_not_in",
-              "description": "name lowercased is not a substring of the parameter, name: the actor's name",
+              "description": "name lower-cased is not a substring of the parameter, name: the actor's name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2745,7 +2614,7 @@
             },
             {
               "name": "name_l_contains",
-              "description": "name lowercased contains the parameter as substring, name: the actor's name",
+              "description": "name lower-cased contains the parameter as substring, name: the actor's name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2755,7 +2624,7 @@
             },
             {
               "name": "name_l_not_contains",
-              "description": "name lowercased doesn't contain the parameter as substring, name: the actor's name",
+              "description": "name lower-cased doesn't contain the parameter as substring, name: the actor's name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2765,7 +2634,7 @@
             },
             {
               "name": "name_l_starts_with",
-              "description": "name lowercased starts with the parameter value, name: the actor's name",
+              "description": "name lower-cased starts with the parameter value, name: the actor's name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2775,7 +2644,7 @@
             },
             {
               "name": "name_l_not_starts_with",
-              "description": "name lowercased doesn't start with the parameter value, name: the actor's name",
+              "description": "name lower-cased doesn't start with the parameter value, name: the actor's name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2785,7 +2654,7 @@
             },
             {
               "name": "name_l_ends_with",
-              "description": "name lowercased ends with the parameter value, name: the actor's name",
+              "description": "name lower-cased ends with the parameter value, name: the actor's name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2795,7 +2664,7 @@
             },
             {
               "name": "name_l_not_ends_with",
-              "description": "name lowercased doesn't end with the parameter value, name: the actor's name",
+              "description": "name lower-cased doesn't end with the parameter value, name: the actor's name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3025,7 +2894,7 @@
             },
             {
               "name": "address_l",
-              "description": "address lowercased equals the parameter, address: the actor's address",
+              "description": "address lower-cased equals the parameter, address: the actor's address",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3035,7 +2904,7 @@
             },
             {
               "name": "address_l_not",
-              "description": "address lowercased doesn't equal the parameter, address: the actor's address",
+              "description": "address lower-cased doesn't equal the parameter, address: the actor's address",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3045,7 +2914,7 @@
             },
             {
               "name": "address_l_in",
-              "description": "address lowercased is a substring of the parameter, address: the actor's address",
+              "description": "address lower-cased is a substring of the parameter, address: the actor's address",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3055,7 +2924,7 @@
             },
             {
               "name": "address_l_not_in",
-              "description": "address lowercased is not a substring of the parameter, address: the actor's address",
+              "description": "address lower-cased is not a substring of the parameter, address: the actor's address",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3065,7 +2934,7 @@
             },
             {
               "name": "address_l_contains",
-              "description": "address lowercased contains the parameter as substring, address: the actor's address",
+              "description": "address lower-cased contains the parameter as substring, address: the actor's address",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3075,7 +2944,7 @@
             },
             {
               "name": "address_l_not_contains",
-              "description": "address lowercased doesn't contain the parameter as substring, address: the actor's address",
+              "description": "address lower-cased doesn't contain the parameter as substring, address: the actor's address",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3085,7 +2954,7 @@
             },
             {
               "name": "address_l_starts_with",
-              "description": "address lowercased starts with the parameter value, address: the actor's address",
+              "description": "address lower-cased starts with the parameter value, address: the actor's address",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3095,7 +2964,7 @@
             },
             {
               "name": "address_l_not_starts_with",
-              "description": "address lowercased doesn't start with the parameter value, address: the actor's address",
+              "description": "address lower-cased doesn't start with the parameter value, address: the actor's address",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3105,7 +2974,7 @@
             },
             {
               "name": "address_l_ends_with",
-              "description": "address lowercased ends with the parameter value, address: the actor's address",
+              "description": "address lower-cased ends with the parameter value, address: the actor's address",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3115,7 +2984,7 @@
             },
             {
               "name": "address_l_not_ends_with",
-              "description": "address lowercased doesn't end with the parameter value, address: the actor's address",
+              "description": "address lower-cased doesn't end with the parameter value, address: the actor's address",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3225,7 +3094,7 @@
             },
             {
               "name": "parentAddress_l",
-              "description": "parentAddress lowercased equals the parameter, parentAddress: the actor's parent's address",
+              "description": "parentAddress lower-cased equals the parameter, parentAddress: the actor's parent's address",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3235,7 +3104,7 @@
             },
             {
               "name": "parentAddress_l_not",
-              "description": "parentAddress lowercased doesn't equal the parameter, parentAddress: the actor's parent's address",
+              "description": "parentAddress lower-cased doesn't equal the parameter, parentAddress: the actor's parent's address",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3245,7 +3114,7 @@
             },
             {
               "name": "parentAddress_l_in",
-              "description": "parentAddress lowercased is a substring of the parameter, parentAddress: the actor's parent's address",
+              "description": "parentAddress lower-cased is a substring of the parameter, parentAddress: the actor's parent's address",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3255,7 +3124,7 @@
             },
             {
               "name": "parentAddress_l_not_in",
-              "description": "parentAddress lowercased is not a substring of the parameter, parentAddress: the actor's parent's address",
+              "description": "parentAddress lower-cased is not a substring of the parameter, parentAddress: the actor's parent's address",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3265,7 +3134,7 @@
             },
             {
               "name": "parentAddress_l_contains",
-              "description": "parentAddress lowercased contains the parameter as substring, parentAddress: the actor's parent's address",
+              "description": "parentAddress lower-cased contains the parameter as substring, parentAddress: the actor's parent's address",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3275,7 +3144,7 @@
             },
             {
               "name": "parentAddress_l_not_contains",
-              "description": "parentAddress lowercased doesn't contain the parameter as substring, parentAddress: the actor's parent's address",
+              "description": "parentAddress lower-cased doesn't contain the parameter as substring, parentAddress: the actor's parent's address",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3285,7 +3154,7 @@
             },
             {
               "name": "parentAddress_l_starts_with",
-              "description": "parentAddress lowercased starts with the parameter value, parentAddress: the actor's parent's address",
+              "description": "parentAddress lower-cased starts with the parameter value, parentAddress: the actor's parent's address",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3295,7 +3164,7 @@
             },
             {
               "name": "parentAddress_l_not_starts_with",
-              "description": "parentAddress lowercased doesn't start with the parameter value, parentAddress: the actor's parent's address",
+              "description": "parentAddress lower-cased doesn't start with the parameter value, parentAddress: the actor's parent's address",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3305,7 +3174,7 @@
             },
             {
               "name": "parentAddress_l_ends_with",
-              "description": "parentAddress lowercased ends with the parameter value, parentAddress: the actor's parent's address",
+              "description": "parentAddress lower-cased ends with the parameter value, parentAddress: the actor's parent's address",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3315,7 +3184,7 @@
             },
             {
               "name": "parentAddress_l_not_ends_with",
-              "description": "parentAddress lowercased doesn't end with the parameter value, parentAddress: the actor's parent's address",
+              "description": "parentAddress lower-cased doesn't end with the parameter value, parentAddress: the actor's parent's address",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3330,20 +3199,128 @@
         },
         {
           "kind": "ENUM",
-          "name": "KlusterKiteMonitoring_Pair_System_String_Node__Sort",
+          "name": "KlusterKiteMonitoring_Node_Sort",
           "description": null,
           "fields": null,
           "inputFields": null,
           "interfaces": null,
           "enumValues": [
             {
-              "name": "key_asc",
+              "name": "actorType_asc",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "key_desc",
+              "name": "actorType_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currentMessage_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currentMessage_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dispatcherId_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dispatcherId_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dispatcherType_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dispatcherType_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "maxQueueSize_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "maxQueueSize_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "queueSize_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "queueSize_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "queueSizeSum_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "queueSizeSum_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "address_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "address_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "parentAddress_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "parentAddress_desc",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -3479,7 +3456,7 @@
             },
             {
               "name": "key_l",
-              "description": "key lowercased equals the parameter, key: Gets a dictionary key",
+              "description": "key lower-cased equals the parameter, key: Gets a dictionary key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3489,7 +3466,7 @@
             },
             {
               "name": "key_l_not",
-              "description": "key lowercased doesn't equal the parameter, key: Gets a dictionary key",
+              "description": "key lower-cased doesn't equal the parameter, key: Gets a dictionary key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3499,7 +3476,7 @@
             },
             {
               "name": "key_l_in",
-              "description": "key lowercased is a substring of the parameter, key: Gets a dictionary key",
+              "description": "key lower-cased is a substring of the parameter, key: Gets a dictionary key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3509,7 +3486,7 @@
             },
             {
               "name": "key_l_not_in",
-              "description": "key lowercased is not a substring of the parameter, key: Gets a dictionary key",
+              "description": "key lower-cased is not a substring of the parameter, key: Gets a dictionary key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3519,7 +3496,7 @@
             },
             {
               "name": "key_l_contains",
-              "description": "key lowercased contains the parameter as substring, key: Gets a dictionary key",
+              "description": "key lower-cased contains the parameter as substring, key: Gets a dictionary key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3529,7 +3506,7 @@
             },
             {
               "name": "key_l_not_contains",
-              "description": "key lowercased doesn't contain the parameter as substring, key: Gets a dictionary key",
+              "description": "key lower-cased doesn't contain the parameter as substring, key: Gets a dictionary key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3539,7 +3516,7 @@
             },
             {
               "name": "key_l_starts_with",
-              "description": "key lowercased starts with the parameter value, key: Gets a dictionary key",
+              "description": "key lower-cased starts with the parameter value, key: Gets a dictionary key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3549,7 +3526,7 @@
             },
             {
               "name": "key_l_not_starts_with",
-              "description": "key lowercased doesn't start with the parameter value, key: Gets a dictionary key",
+              "description": "key lower-cased doesn't start with the parameter value, key: Gets a dictionary key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3559,7 +3536,7 @@
             },
             {
               "name": "key_l_ends_with",
-              "description": "key lowercased ends with the parameter value, key: Gets a dictionary key",
+              "description": "key lower-cased ends with the parameter value, key: Gets a dictionary key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3569,7 +3546,7 @@
             },
             {
               "name": "key_l_not_ends_with",
-              "description": "key lowercased doesn't end with the parameter value, key: Gets a dictionary key",
+              "description": "key lower-cased doesn't end with the parameter value, key: Gets a dictionary key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3580,6 +3557,29 @@
           ],
           "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "KlusterKiteMonitoring_Pair_System_String_Node__Sort",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "key_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "key_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -3612,7 +3612,7 @@
               "deprecationReason": null
             },
             {
-              "name": "node",
+              "name": "_node",
               "description": "The node global searcher according to Relay specification",
               "args": [
                 {
@@ -3636,7 +3636,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -3665,17 +3665,12 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
               "kind": "OBJECT",
-              "name": "KlusterKiteMonitoring_Root",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "KlusterKiteMonitoring_ClusterTree",
+              "name": "KlusterKiteMonitoring_Node",
               "ofType": null
             },
             {
@@ -3685,37 +3680,7 @@
             },
             {
               "kind": "OBJECT",
-              "name": "KlusterKiteMonitoring_Node",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "KlusterKiteNodeApi_Root",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "KlusterKiteNodeApi_ClusterManagement",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "KlusterKiteNodeApi_Configuration",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "KlusterKiteNodeApi_ConfigurationSettings",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
               "name": "KlusterKiteNodeApi_PackageDescription",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "KlusterKiteNodeApi_NodeTemplate",
               "ofType": null
             },
             {
@@ -3726,6 +3691,11 @@
             {
               "kind": "OBJECT",
               "name": "KlusterKiteNodeApi_Pair_System_String_List_PackageDescription__",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "KlusterKiteNodeApi_NodeTemplate",
               "ofType": null
             },
             {
@@ -3745,17 +3715,7 @@
             },
             {
               "kind": "OBJECT",
-              "name": "KlusterKiteNodeApi_ResourceState",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "KlusterKiteNodeApi_MigrationActorMigrationState",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "KlusterKiteNodeApi_MigratorTemplateMigrationState",
+              "name": "KlusterKiteNodeApi_ResourceMigrationState",
               "ofType": null
             },
             {
@@ -3765,22 +3725,7 @@
             },
             {
               "kind": "OBJECT",
-              "name": "KlusterKiteNodeApi_ResourceMigrationState",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "KlusterKiteNodeApi_MigrationActorConfigurationState",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "KlusterKiteNodeApi_MigratorTemplateConfigurationState",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "KlusterKiteNodeApi_MigratorConfigurationState",
+              "name": "KlusterKiteNodeApi_MigratorTemplateMigrationState",
               "ofType": null
             },
             {
@@ -3790,7 +3735,12 @@
             },
             {
               "kind": "OBJECT",
-              "name": "KlusterKiteNodeApi_Migration",
+              "name": "KlusterKiteNodeApi_MigratorConfigurationState",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "KlusterKiteNodeApi_MigratorTemplateConfigurationState",
               "ofType": null
             },
             {
@@ -3805,22 +3755,17 @@
             },
             {
               "kind": "OBJECT",
-              "name": "KlusterKiteNodeApi_AkkaAddress",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "KlusterKiteNodeApi_TemplatesStatistics",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
               "name": "KlusterKiteNodeApi_TemplatesStatisticsData",
               "ofType": null
             },
             {
               "kind": "OBJECT",
-              "name": "KlusterKiteNodeApi_Role",
+              "name": "KlusterKiteNodeApi_Migration",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "KlusterKiteNodeApi_Configuration",
               "ofType": null
             },
             {
@@ -3830,7 +3775,67 @@
             },
             {
               "kind": "OBJECT",
+              "name": "KlusterKiteNodeApi_Role",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "KlusterKiteNodeApi_User",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "KlusterKiteNodeApi_ErrorDescription",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "KlusterKiteMonitoring_Root",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "KlusterKiteMonitoring_ClusterTree",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "KlusterKiteNodeApi_Root",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "KlusterKiteNodeApi_ClusterManagement",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "KlusterKiteNodeApi_ConfigurationSettings",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "KlusterKiteNodeApi_ResourceState",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "KlusterKiteNodeApi_MigrationActorMigrationState",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "KlusterKiteNodeApi_MigrationActorConfigurationState",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "KlusterKiteNodeApi_AkkaAddress",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "KlusterKiteNodeApi_TemplatesStatistics",
               "ofType": null
             },
             {
@@ -3846,11 +3851,6 @@
             {
               "kind": "OBJECT",
               "name": "KlusterKiteNodeApi_MutationResult_System_Boolean_",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "KlusterKiteNodeApi_ErrorDescription",
               "ofType": null
             },
             {
@@ -3904,6 +3904,16 @@
               "description": "The packages in the Nuget repository",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -3914,11 +3924,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_NugetPackageFamily_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -3938,21 +3948,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_NugetPackageFamily_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -3971,6 +3971,16 @@
               "description": "The list of known active nodes",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -3981,11 +3991,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Uid",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_NodeDescription_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -4005,21 +4015,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_NodeDescription_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "Guid",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -4050,6 +4050,16 @@
               "description": "the cluster migration management",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -4060,11 +4070,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_Migration_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -4084,17 +4094,7 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_Migration_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -4117,6 +4117,16 @@
               "description": "KlusterKite managing system security roles",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -4127,11 +4137,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_Configuration_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -4151,17 +4161,7 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_Configuration_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -4184,6 +4184,16 @@
               "description": "KlusterKite managing system security roles",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -4194,11 +4204,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Uid",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_Role_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -4218,21 +4228,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_Role_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "Guid",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -4251,6 +4251,16 @@
               "description": "KlusterKite managing system users",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -4261,11 +4271,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Uid",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_User_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -4285,21 +4295,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_User_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "Guid",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -4315,7 +4315,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -4380,7 +4380,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -4473,7 +4473,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -4485,7 +4485,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -4497,7 +4497,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -4544,6 +4544,16 @@
               "description": "the list of compatible node templates",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -4554,11 +4564,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_CompatibleTemplate_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -4578,17 +4588,7 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_CompatibleTemplate_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -4611,6 +4611,16 @@
               "description": "the list of compatible node templates",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -4621,11 +4631,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_CompatibleTemplate_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -4645,17 +4655,7 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_CompatibleTemplate_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -4678,6 +4678,16 @@
               "description": "the list of migration logs",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -4688,11 +4698,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_MigrationLogRecord_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -4712,17 +4722,7 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_MigrationLogRecord_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -4742,7 +4742,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -4751,6 +4751,16 @@
               "ofType": null
             }
           ]
+        },
+        {
+          "kind": "SCALAR",
+          "name": "DateTime",
+          "description": "The `DateTime` scalar type represents a date and time. `DateTime` expects timestamps to be formatted in accordance with the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
         },
         {
           "kind": "ENUM",
@@ -4821,6 +4831,16 @@
               "description": "the list of available packages with their versions",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -4831,11 +4851,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_PackageDescription_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -4855,21 +4875,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_PackageDescription_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -4888,6 +4898,16 @@
               "description": "the list of configured node templates",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -4898,11 +4918,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_NodeTemplate_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -4922,21 +4942,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_NodeTemplate_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -4955,6 +4965,16 @@
               "description": "the list of configured cluster migrator templates",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -4965,11 +4985,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_MigratorTemplate_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -4989,21 +5009,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_MigratorTemplate_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -5047,7 +5057,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -5092,7 +5102,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -5133,7 +5143,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -5186,7 +5196,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -5195,41 +5205,6 @@
               "ofType": null
             }
           ]
-        },
-        {
-          "kind": "ENUM",
-          "name": "KlusterKiteNodeApi_PackageDescription_Sort",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "id_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "version_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "version_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
         },
         {
           "kind": "INPUT_OBJECT",
@@ -5359,7 +5334,7 @@
             },
             {
               "name": "id_l",
-              "description": "id lowercased equals the parameter, id: the package Id",
+              "description": "id lower-cased equals the parameter, id: the package Id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -5369,7 +5344,7 @@
             },
             {
               "name": "id_l_not",
-              "description": "id lowercased doesn't equal the parameter, id: the package Id",
+              "description": "id lower-cased doesn't equal the parameter, id: the package Id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -5379,7 +5354,7 @@
             },
             {
               "name": "id_l_in",
-              "description": "id lowercased is a substring of the parameter, id: the package Id",
+              "description": "id lower-cased is a substring of the parameter, id: the package Id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -5389,7 +5364,7 @@
             },
             {
               "name": "id_l_not_in",
-              "description": "id lowercased is not a substring of the parameter, id: the package Id",
+              "description": "id lower-cased is not a substring of the parameter, id: the package Id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -5399,7 +5374,7 @@
             },
             {
               "name": "id_l_contains",
-              "description": "id lowercased contains the parameter as substring, id: the package Id",
+              "description": "id lower-cased contains the parameter as substring, id: the package Id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -5409,7 +5384,7 @@
             },
             {
               "name": "id_l_not_contains",
-              "description": "id lowercased doesn't contain the parameter as substring, id: the package Id",
+              "description": "id lower-cased doesn't contain the parameter as substring, id: the package Id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -5419,7 +5394,7 @@
             },
             {
               "name": "id_l_starts_with",
-              "description": "id lowercased starts with the parameter value, id: the package Id",
+              "description": "id lower-cased starts with the parameter value, id: the package Id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -5429,7 +5404,7 @@
             },
             {
               "name": "id_l_not_starts_with",
-              "description": "id lowercased doesn't start with the parameter value, id: the package Id",
+              "description": "id lower-cased doesn't start with the parameter value, id: the package Id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -5439,7 +5414,7 @@
             },
             {
               "name": "id_l_ends_with",
-              "description": "id lowercased ends with the parameter value, id: the package Id",
+              "description": "id lower-cased ends with the parameter value, id: the package Id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -5449,7 +5424,7 @@
             },
             {
               "name": "id_l_not_ends_with",
-              "description": "id lowercased doesn't end with the parameter value, id: the package Id",
+              "description": "id lower-cased doesn't end with the parameter value, id: the package Id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -5559,7 +5534,7 @@
             },
             {
               "name": "version_l",
-              "description": "version lowercased equals the parameter, version: the package version",
+              "description": "version lower-cased equals the parameter, version: the package version",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -5569,7 +5544,7 @@
             },
             {
               "name": "version_l_not",
-              "description": "version lowercased doesn't equal the parameter, version: the package version",
+              "description": "version lower-cased doesn't equal the parameter, version: the package version",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -5579,7 +5554,7 @@
             },
             {
               "name": "version_l_in",
-              "description": "version lowercased is a substring of the parameter, version: the package version",
+              "description": "version lower-cased is a substring of the parameter, version: the package version",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -5589,7 +5564,7 @@
             },
             {
               "name": "version_l_not_in",
-              "description": "version lowercased is not a substring of the parameter, version: the package version",
+              "description": "version lower-cased is not a substring of the parameter, version: the package version",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -5599,7 +5574,7 @@
             },
             {
               "name": "version_l_contains",
-              "description": "version lowercased contains the parameter as substring, version: the package version",
+              "description": "version lower-cased contains the parameter as substring, version: the package version",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -5609,7 +5584,7 @@
             },
             {
               "name": "version_l_not_contains",
-              "description": "version lowercased doesn't contain the parameter as substring, version: the package version",
+              "description": "version lower-cased doesn't contain the parameter as substring, version: the package version",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -5619,7 +5594,7 @@
             },
             {
               "name": "version_l_starts_with",
-              "description": "version lowercased starts with the parameter value, version: the package version",
+              "description": "version lower-cased starts with the parameter value, version: the package version",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -5629,7 +5604,7 @@
             },
             {
               "name": "version_l_not_starts_with",
-              "description": "version lowercased doesn't start with the parameter value, version: the package version",
+              "description": "version lower-cased doesn't start with the parameter value, version: the package version",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -5639,7 +5614,7 @@
             },
             {
               "name": "version_l_ends_with",
-              "description": "version lowercased ends with the parameter value, version: the package version",
+              "description": "version lower-cased ends with the parameter value, version: the package version",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -5649,7 +5624,7 @@
             },
             {
               "name": "version_l_not_ends_with",
-              "description": "version lowercased doesn't end with the parameter value, version: the package version",
+              "description": "version lower-cased doesn't end with the parameter value, version: the package version",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -5660,6 +5635,41 @@
           ],
           "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "KlusterKiteNodeApi_PackageDescription_Sort",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "id_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "version_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "version_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -5697,7 +5707,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -5738,7 +5748,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -5870,6 +5880,16 @@
               "description": "The list of package requirements",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -5880,11 +5900,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_PackageRequirement_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -5904,21 +5924,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_PackageRequirement_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -5937,6 +5947,16 @@
               "description": "The list of packages to install for current template",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -5947,11 +5967,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_Pair_System_String_List_PackageDescription___Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -5971,21 +5991,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_Pair_System_String_List_PackageDescription___Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -6013,7 +6023,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -6022,6 +6032,16 @@
               "ofType": null
             }
           ]
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Float",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
         },
         {
           "kind": "INTERFACE",
@@ -6058,7 +6078,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -6099,7 +6119,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -6152,7 +6172,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -6161,41 +6181,6 @@
               "ofType": null
             }
           ]
-        },
-        {
-          "kind": "ENUM",
-          "name": "KlusterKiteNodeApi_PackageRequirement_Sort",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "id_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "specificVersion_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "specificVersion_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
         },
         {
           "kind": "INPUT_OBJECT",
@@ -6325,7 +6310,7 @@
             },
             {
               "name": "id_l",
-              "description": "id lowercased equals the parameter, id: the Nuget package id",
+              "description": "id lower-cased equals the parameter, id: the Nuget package id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -6335,7 +6320,7 @@
             },
             {
               "name": "id_l_not",
-              "description": "id lowercased doesn't equal the parameter, id: the Nuget package id",
+              "description": "id lower-cased doesn't equal the parameter, id: the Nuget package id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -6345,7 +6330,7 @@
             },
             {
               "name": "id_l_in",
-              "description": "id lowercased is a substring of the parameter, id: the Nuget package id",
+              "description": "id lower-cased is a substring of the parameter, id: the Nuget package id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -6355,7 +6340,7 @@
             },
             {
               "name": "id_l_not_in",
-              "description": "id lowercased is not a substring of the parameter, id: the Nuget package id",
+              "description": "id lower-cased is not a substring of the parameter, id: the Nuget package id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -6365,7 +6350,7 @@
             },
             {
               "name": "id_l_contains",
-              "description": "id lowercased contains the parameter as substring, id: the Nuget package id",
+              "description": "id lower-cased contains the parameter as substring, id: the Nuget package id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -6375,7 +6360,7 @@
             },
             {
               "name": "id_l_not_contains",
-              "description": "id lowercased doesn't contain the parameter as substring, id: the Nuget package id",
+              "description": "id lower-cased doesn't contain the parameter as substring, id: the Nuget package id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -6385,7 +6370,7 @@
             },
             {
               "name": "id_l_starts_with",
-              "description": "id lowercased starts with the parameter value, id: the Nuget package id",
+              "description": "id lower-cased starts with the parameter value, id: the Nuget package id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -6395,7 +6380,7 @@
             },
             {
               "name": "id_l_not_starts_with",
-              "description": "id lowercased doesn't start with the parameter value, id: the Nuget package id",
+              "description": "id lower-cased doesn't start with the parameter value, id: the Nuget package id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -6405,7 +6390,7 @@
             },
             {
               "name": "id_l_ends_with",
-              "description": "id lowercased ends with the parameter value, id: the Nuget package id",
+              "description": "id lower-cased ends with the parameter value, id: the Nuget package id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -6415,7 +6400,7 @@
             },
             {
               "name": "id_l_not_ends_with",
-              "description": "id lowercased doesn't end with the parameter value, id: the Nuget package id",
+              "description": "id lower-cased doesn't end with the parameter value, id: the Nuget package id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -6525,7 +6510,7 @@
             },
             {
               "name": "specificVersion_l",
-              "description": "specificVersion lowercased equals the parameter, specificVersion: the required specific version (in case of null the default version for configuration will be used)",
+              "description": "specificVersion lower-cased equals the parameter, specificVersion: the required specific version (in case of null the default version for configuration will be used)",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -6535,7 +6520,7 @@
             },
             {
               "name": "specificVersion_l_not",
-              "description": "specificVersion lowercased doesn't equal the parameter, specificVersion: the required specific version (in case of null the default version for configuration will be used)",
+              "description": "specificVersion lower-cased doesn't equal the parameter, specificVersion: the required specific version (in case of null the default version for configuration will be used)",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -6545,7 +6530,7 @@
             },
             {
               "name": "specificVersion_l_in",
-              "description": "specificVersion lowercased is a substring of the parameter, specificVersion: the required specific version (in case of null the default version for configuration will be used)",
+              "description": "specificVersion lower-cased is a substring of the parameter, specificVersion: the required specific version (in case of null the default version for configuration will be used)",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -6555,7 +6540,7 @@
             },
             {
               "name": "specificVersion_l_not_in",
-              "description": "specificVersion lowercased is not a substring of the parameter, specificVersion: the required specific version (in case of null the default version for configuration will be used)",
+              "description": "specificVersion lower-cased is not a substring of the parameter, specificVersion: the required specific version (in case of null the default version for configuration will be used)",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -6565,7 +6550,7 @@
             },
             {
               "name": "specificVersion_l_contains",
-              "description": "specificVersion lowercased contains the parameter as substring, specificVersion: the required specific version (in case of null the default version for configuration will be used)",
+              "description": "specificVersion lower-cased contains the parameter as substring, specificVersion: the required specific version (in case of null the default version for configuration will be used)",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -6575,7 +6560,7 @@
             },
             {
               "name": "specificVersion_l_not_contains",
-              "description": "specificVersion lowercased doesn't contain the parameter as substring, specificVersion: the required specific version (in case of null the default version for configuration will be used)",
+              "description": "specificVersion lower-cased doesn't contain the parameter as substring, specificVersion: the required specific version (in case of null the default version for configuration will be used)",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -6585,7 +6570,7 @@
             },
             {
               "name": "specificVersion_l_starts_with",
-              "description": "specificVersion lowercased starts with the parameter value, specificVersion: the required specific version (in case of null the default version for configuration will be used)",
+              "description": "specificVersion lower-cased starts with the parameter value, specificVersion: the required specific version (in case of null the default version for configuration will be used)",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -6595,7 +6580,7 @@
             },
             {
               "name": "specificVersion_l_not_starts_with",
-              "description": "specificVersion lowercased doesn't start with the parameter value, specificVersion: the required specific version (in case of null the default version for configuration will be used)",
+              "description": "specificVersion lower-cased doesn't start with the parameter value, specificVersion: the required specific version (in case of null the default version for configuration will be used)",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -6605,7 +6590,7 @@
             },
             {
               "name": "specificVersion_l_ends_with",
-              "description": "specificVersion lowercased ends with the parameter value, specificVersion: the required specific version (in case of null the default version for configuration will be used)",
+              "description": "specificVersion lower-cased ends with the parameter value, specificVersion: the required specific version (in case of null the default version for configuration will be used)",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -6615,7 +6600,7 @@
             },
             {
               "name": "specificVersion_l_not_ends_with",
-              "description": "specificVersion lowercased doesn't end with the parameter value, specificVersion: the required specific version (in case of null the default version for configuration will be used)",
+              "description": "specificVersion lower-cased doesn't end with the parameter value, specificVersion: the required specific version (in case of null the default version for configuration will be used)",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -6626,6 +6611,41 @@
           ],
           "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "KlusterKiteNodeApi_PackageRequirement_Sort",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "id_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "specificVersion_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "specificVersion_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -6663,7 +6683,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -6704,7 +6724,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -6748,6 +6768,16 @@
               "description": "Gets a dictionary value",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -6758,11 +6788,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_PackageDescription_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -6782,21 +6812,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_PackageDescription_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -6812,7 +6832,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -6821,29 +6841,6 @@
               "ofType": null
             }
           ]
-        },
-        {
-          "kind": "ENUM",
-          "name": "KlusterKiteNodeApi_Pair_System_String_List_PackageDescription___Sort",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "key_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "key_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
         },
         {
           "kind": "INPUT_OBJECT",
@@ -6973,7 +6970,7 @@
             },
             {
               "name": "key_l",
-              "description": "key lowercased equals the parameter, key: Gets a dictionary key",
+              "description": "key lower-cased equals the parameter, key: Gets a dictionary key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -6983,7 +6980,7 @@
             },
             {
               "name": "key_l_not",
-              "description": "key lowercased doesn't equal the parameter, key: Gets a dictionary key",
+              "description": "key lower-cased doesn't equal the parameter, key: Gets a dictionary key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -6993,7 +6990,7 @@
             },
             {
               "name": "key_l_in",
-              "description": "key lowercased is a substring of the parameter, key: Gets a dictionary key",
+              "description": "key lower-cased is a substring of the parameter, key: Gets a dictionary key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7003,7 +7000,7 @@
             },
             {
               "name": "key_l_not_in",
-              "description": "key lowercased is not a substring of the parameter, key: Gets a dictionary key",
+              "description": "key lower-cased is not a substring of the parameter, key: Gets a dictionary key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7013,7 +7010,7 @@
             },
             {
               "name": "key_l_contains",
-              "description": "key lowercased contains the parameter as substring, key: Gets a dictionary key",
+              "description": "key lower-cased contains the parameter as substring, key: Gets a dictionary key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7023,7 +7020,7 @@
             },
             {
               "name": "key_l_not_contains",
-              "description": "key lowercased doesn't contain the parameter as substring, key: Gets a dictionary key",
+              "description": "key lower-cased doesn't contain the parameter as substring, key: Gets a dictionary key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7033,7 +7030,7 @@
             },
             {
               "name": "key_l_starts_with",
-              "description": "key lowercased starts with the parameter value, key: Gets a dictionary key",
+              "description": "key lower-cased starts with the parameter value, key: Gets a dictionary key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7043,7 +7040,7 @@
             },
             {
               "name": "key_l_not_starts_with",
-              "description": "key lowercased doesn't start with the parameter value, key: Gets a dictionary key",
+              "description": "key lower-cased doesn't start with the parameter value, key: Gets a dictionary key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7053,7 +7050,7 @@
             },
             {
               "name": "key_l_ends_with",
-              "description": "key lowercased ends with the parameter value, key: Gets a dictionary key",
+              "description": "key lower-cased ends with the parameter value, key: Gets a dictionary key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7063,7 +7060,7 @@
             },
             {
               "name": "key_l_not_ends_with",
-              "description": "key lowercased doesn't end with the parameter value, key: Gets a dictionary key",
+              "description": "key lower-cased doesn't end with the parameter value, key: Gets a dictionary key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7078,104 +7075,20 @@
         },
         {
           "kind": "ENUM",
-          "name": "KlusterKiteNodeApi_NodeTemplate_Sort",
+          "name": "KlusterKiteNodeApi_Pair_System_String_List_PackageDescription___Sort",
           "description": null,
           "fields": null,
           "inputFields": null,
           "interfaces": null,
           "enumValues": [
             {
-              "name": "code_asc",
+              "name": "key_asc",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "code_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "configuration_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "configuration_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "maximumNeededInstances_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "maximumNeededInstances_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "minimumRequiredInstances_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "minimumRequiredInstances_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "notes_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "notes_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "priority_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "priority_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "forceUpdate_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "forceUpdate_desc",
+              "name": "key_desc",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -7311,7 +7224,7 @@
             },
             {
               "name": "code_l",
-              "description": "code lowercased equals the parameter, code: The program readable node template name",
+              "description": "code lower-cased equals the parameter, code: The program readable node template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7321,7 +7234,7 @@
             },
             {
               "name": "code_l_not",
-              "description": "code lowercased doesn't equal the parameter, code: The program readable node template name",
+              "description": "code lower-cased doesn't equal the parameter, code: The program readable node template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7331,7 +7244,7 @@
             },
             {
               "name": "code_l_in",
-              "description": "code lowercased is a substring of the parameter, code: The program readable node template name",
+              "description": "code lower-cased is a substring of the parameter, code: The program readable node template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7341,7 +7254,7 @@
             },
             {
               "name": "code_l_not_in",
-              "description": "code lowercased is not a substring of the parameter, code: The program readable node template name",
+              "description": "code lower-cased is not a substring of the parameter, code: The program readable node template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7351,7 +7264,7 @@
             },
             {
               "name": "code_l_contains",
-              "description": "code lowercased contains the parameter as substring, code: The program readable node template name",
+              "description": "code lower-cased contains the parameter as substring, code: The program readable node template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7361,7 +7274,7 @@
             },
             {
               "name": "code_l_not_contains",
-              "description": "code lowercased doesn't contain the parameter as substring, code: The program readable node template name",
+              "description": "code lower-cased doesn't contain the parameter as substring, code: The program readable node template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7371,7 +7284,7 @@
             },
             {
               "name": "code_l_starts_with",
-              "description": "code lowercased starts with the parameter value, code: The program readable node template name",
+              "description": "code lower-cased starts with the parameter value, code: The program readable node template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7381,7 +7294,7 @@
             },
             {
               "name": "code_l_not_starts_with",
-              "description": "code lowercased doesn't start with the parameter value, code: The program readable node template name",
+              "description": "code lower-cased doesn't start with the parameter value, code: The program readable node template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7391,7 +7304,7 @@
             },
             {
               "name": "code_l_ends_with",
-              "description": "code lowercased ends with the parameter value, code: The program readable node template name",
+              "description": "code lower-cased ends with the parameter value, code: The program readable node template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7401,7 +7314,7 @@
             },
             {
               "name": "code_l_not_ends_with",
-              "description": "code lowercased doesn't end with the parameter value, code: The program readable node template name",
+              "description": "code lower-cased doesn't end with the parameter value, code: The program readable node template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7511,7 +7424,7 @@
             },
             {
               "name": "configuration_l",
-              "description": "configuration lowercased equals the parameter, configuration: The akka configuration template for node",
+              "description": "configuration lower-cased equals the parameter, configuration: The akka configuration template for node",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7521,7 +7434,7 @@
             },
             {
               "name": "configuration_l_not",
-              "description": "configuration lowercased doesn't equal the parameter, configuration: The akka configuration template for node",
+              "description": "configuration lower-cased doesn't equal the parameter, configuration: The akka configuration template for node",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7531,7 +7444,7 @@
             },
             {
               "name": "configuration_l_in",
-              "description": "configuration lowercased is a substring of the parameter, configuration: The akka configuration template for node",
+              "description": "configuration lower-cased is a substring of the parameter, configuration: The akka configuration template for node",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7541,7 +7454,7 @@
             },
             {
               "name": "configuration_l_not_in",
-              "description": "configuration lowercased is not a substring of the parameter, configuration: The akka configuration template for node",
+              "description": "configuration lower-cased is not a substring of the parameter, configuration: The akka configuration template for node",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7551,7 +7464,7 @@
             },
             {
               "name": "configuration_l_contains",
-              "description": "configuration lowercased contains the parameter as substring, configuration: The akka configuration template for node",
+              "description": "configuration lower-cased contains the parameter as substring, configuration: The akka configuration template for node",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7561,7 +7474,7 @@
             },
             {
               "name": "configuration_l_not_contains",
-              "description": "configuration lowercased doesn't contain the parameter as substring, configuration: The akka configuration template for node",
+              "description": "configuration lower-cased doesn't contain the parameter as substring, configuration: The akka configuration template for node",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7571,7 +7484,7 @@
             },
             {
               "name": "configuration_l_starts_with",
-              "description": "configuration lowercased starts with the parameter value, configuration: The akka configuration template for node",
+              "description": "configuration lower-cased starts with the parameter value, configuration: The akka configuration template for node",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7581,7 +7494,7 @@
             },
             {
               "name": "configuration_l_not_starts_with",
-              "description": "configuration lowercased doesn't start with the parameter value, configuration: The akka configuration template for node",
+              "description": "configuration lower-cased doesn't start with the parameter value, configuration: The akka configuration template for node",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7591,7 +7504,7 @@
             },
             {
               "name": "configuration_l_ends_with",
-              "description": "configuration lowercased ends with the parameter value, configuration: The akka configuration template for node",
+              "description": "configuration lower-cased ends with the parameter value, configuration: The akka configuration template for node",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7601,7 +7514,7 @@
             },
             {
               "name": "configuration_l_not_ends_with",
-              "description": "configuration lowercased doesn't end with the parameter value, configuration: The akka configuration template for node",
+              "description": "configuration lower-cased doesn't end with the parameter value, configuration: The akka configuration template for node",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7831,7 +7744,7 @@
             },
             {
               "name": "name_l",
-              "description": "name lowercased equals the parameter, name: The human readable node template name",
+              "description": "name lower-cased equals the parameter, name: The human readable node template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7841,7 +7754,7 @@
             },
             {
               "name": "name_l_not",
-              "description": "name lowercased doesn't equal the parameter, name: The human readable node template name",
+              "description": "name lower-cased doesn't equal the parameter, name: The human readable node template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7851,7 +7764,7 @@
             },
             {
               "name": "name_l_in",
-              "description": "name lowercased is a substring of the parameter, name: The human readable node template name",
+              "description": "name lower-cased is a substring of the parameter, name: The human readable node template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7861,7 +7774,7 @@
             },
             {
               "name": "name_l_not_in",
-              "description": "name lowercased is not a substring of the parameter, name: The human readable node template name",
+              "description": "name lower-cased is not a substring of the parameter, name: The human readable node template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7871,7 +7784,7 @@
             },
             {
               "name": "name_l_contains",
-              "description": "name lowercased contains the parameter as substring, name: The human readable node template name",
+              "description": "name lower-cased contains the parameter as substring, name: The human readable node template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7881,7 +7794,7 @@
             },
             {
               "name": "name_l_not_contains",
-              "description": "name lowercased doesn't contain the parameter as substring, name: The human readable node template name",
+              "description": "name lower-cased doesn't contain the parameter as substring, name: The human readable node template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7891,7 +7804,7 @@
             },
             {
               "name": "name_l_starts_with",
-              "description": "name lowercased starts with the parameter value, name: The human readable node template name",
+              "description": "name lower-cased starts with the parameter value, name: The human readable node template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7901,7 +7814,7 @@
             },
             {
               "name": "name_l_not_starts_with",
-              "description": "name lowercased doesn't start with the parameter value, name: The human readable node template name",
+              "description": "name lower-cased doesn't start with the parameter value, name: The human readable node template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7911,7 +7824,7 @@
             },
             {
               "name": "name_l_ends_with",
-              "description": "name lowercased ends with the parameter value, name: The human readable node template name",
+              "description": "name lower-cased ends with the parameter value, name: The human readable node template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7921,7 +7834,7 @@
             },
             {
               "name": "name_l_not_ends_with",
-              "description": "name lowercased doesn't end with the parameter value, name: The human readable node template name",
+              "description": "name lower-cased doesn't end with the parameter value, name: The human readable node template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8031,7 +7944,7 @@
             },
             {
               "name": "notes_l",
-              "description": "notes lowercased equals the parameter, notes: The template description for other users",
+              "description": "notes lower-cased equals the parameter, notes: The template description for other users",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8041,7 +7954,7 @@
             },
             {
               "name": "notes_l_not",
-              "description": "notes lowercased doesn't equal the parameter, notes: The template description for other users",
+              "description": "notes lower-cased doesn't equal the parameter, notes: The template description for other users",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8051,7 +7964,7 @@
             },
             {
               "name": "notes_l_in",
-              "description": "notes lowercased is a substring of the parameter, notes: The template description for other users",
+              "description": "notes lower-cased is a substring of the parameter, notes: The template description for other users",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8061,7 +7974,7 @@
             },
             {
               "name": "notes_l_not_in",
-              "description": "notes lowercased is not a substring of the parameter, notes: The template description for other users",
+              "description": "notes lower-cased is not a substring of the parameter, notes: The template description for other users",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8071,7 +7984,7 @@
             },
             {
               "name": "notes_l_contains",
-              "description": "notes lowercased contains the parameter as substring, notes: The template description for other users",
+              "description": "notes lower-cased contains the parameter as substring, notes: The template description for other users",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8081,7 +7994,7 @@
             },
             {
               "name": "notes_l_not_contains",
-              "description": "notes lowercased doesn't contain the parameter as substring, notes: The template description for other users",
+              "description": "notes lower-cased doesn't contain the parameter as substring, notes: The template description for other users",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8091,7 +8004,7 @@
             },
             {
               "name": "notes_l_starts_with",
-              "description": "notes lowercased starts with the parameter value, notes: The template description for other users",
+              "description": "notes lower-cased starts with the parameter value, notes: The template description for other users",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8101,7 +8014,7 @@
             },
             {
               "name": "notes_l_not_starts_with",
-              "description": "notes lowercased doesn't start with the parameter value, notes: The template description for other users",
+              "description": "notes lower-cased doesn't start with the parameter value, notes: The template description for other users",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8111,7 +8024,7 @@
             },
             {
               "name": "notes_l_ends_with",
-              "description": "notes lowercased ends with the parameter value, notes: The template description for other users",
+              "description": "notes lower-cased ends with the parameter value, notes: The template description for other users",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8121,7 +8034,7 @@
             },
             {
               "name": "notes_l_not_ends_with",
-              "description": "notes lowercased doesn't end with the parameter value, notes: The template description for other users",
+              "description": "notes lower-cased doesn't end with the parameter value, notes: The template description for other users",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8215,6 +8128,113 @@
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "KlusterKiteNodeApi_NodeTemplate_Sort",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "code_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "code_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "configuration_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "configuration_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "maximumNeededInstances_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "maximumNeededInstances_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "minimumRequiredInstances_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "minimumRequiredInstances_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "notes_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "notes_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "priority_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "priority_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "forceUpdate_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "forceUpdate_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
           "kind": "INTERFACE",
           "name": "IKlusterKiteNodeApi_MigratorTemplate_Connection",
           "description": "The list of connected KlusterKiteNodeApi_MigratorTemplate\n A cluster migrator template definition",
@@ -8249,7 +8269,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -8290,7 +8310,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -8382,6 +8402,16 @@
               "description": "The list of package requirements",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -8392,11 +8422,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_PackageRequirement_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -8416,21 +8446,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_PackageRequirement_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -8449,6 +8469,16 @@
               "description": "The list of packages to install for current template",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -8459,11 +8489,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_Pair_System_String_List_PackageDescription___Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -8483,21 +8513,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_Pair_System_String_List_PackageDescription___Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -8513,7 +8533,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -8522,77 +8542,6 @@
               "ofType": null
             }
           ]
-        },
-        {
-          "kind": "ENUM",
-          "name": "KlusterKiteNodeApi_MigratorTemplate_Sort",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "code_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "code_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "configuration_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "configuration_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "notes_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "notes_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "priority_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "priority_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
         },
         {
           "kind": "INPUT_OBJECT",
@@ -8722,7 +8671,7 @@
             },
             {
               "name": "code_l",
-              "description": "code lowercased equals the parameter, code: The program readable migrator template name",
+              "description": "code lower-cased equals the parameter, code: The program readable migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8732,7 +8681,7 @@
             },
             {
               "name": "code_l_not",
-              "description": "code lowercased doesn't equal the parameter, code: The program readable migrator template name",
+              "description": "code lower-cased doesn't equal the parameter, code: The program readable migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8742,7 +8691,7 @@
             },
             {
               "name": "code_l_in",
-              "description": "code lowercased is a substring of the parameter, code: The program readable migrator template name",
+              "description": "code lower-cased is a substring of the parameter, code: The program readable migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8752,7 +8701,7 @@
             },
             {
               "name": "code_l_not_in",
-              "description": "code lowercased is not a substring of the parameter, code: The program readable migrator template name",
+              "description": "code lower-cased is not a substring of the parameter, code: The program readable migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8762,7 +8711,7 @@
             },
             {
               "name": "code_l_contains",
-              "description": "code lowercased contains the parameter as substring, code: The program readable migrator template name",
+              "description": "code lower-cased contains the parameter as substring, code: The program readable migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8772,7 +8721,7 @@
             },
             {
               "name": "code_l_not_contains",
-              "description": "code lowercased doesn't contain the parameter as substring, code: The program readable migrator template name",
+              "description": "code lower-cased doesn't contain the parameter as substring, code: The program readable migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8782,7 +8731,7 @@
             },
             {
               "name": "code_l_starts_with",
-              "description": "code lowercased starts with the parameter value, code: The program readable migrator template name",
+              "description": "code lower-cased starts with the parameter value, code: The program readable migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8792,7 +8741,7 @@
             },
             {
               "name": "code_l_not_starts_with",
-              "description": "code lowercased doesn't start with the parameter value, code: The program readable migrator template name",
+              "description": "code lower-cased doesn't start with the parameter value, code: The program readable migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8802,7 +8751,7 @@
             },
             {
               "name": "code_l_ends_with",
-              "description": "code lowercased ends with the parameter value, code: The program readable migrator template name",
+              "description": "code lower-cased ends with the parameter value, code: The program readable migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8812,7 +8761,7 @@
             },
             {
               "name": "code_l_not_ends_with",
-              "description": "code lowercased doesn't end with the parameter value, code: The program readable migrator template name",
+              "description": "code lower-cased doesn't end with the parameter value, code: The program readable migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8922,7 +8871,7 @@
             },
             {
               "name": "configuration_l",
-              "description": "configuration lowercased equals the parameter, configuration: The akka configuration for migrator",
+              "description": "configuration lower-cased equals the parameter, configuration: The akka configuration for migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8932,7 +8881,7 @@
             },
             {
               "name": "configuration_l_not",
-              "description": "configuration lowercased doesn't equal the parameter, configuration: The akka configuration for migrator",
+              "description": "configuration lower-cased doesn't equal the parameter, configuration: The akka configuration for migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8942,7 +8891,7 @@
             },
             {
               "name": "configuration_l_in",
-              "description": "configuration lowercased is a substring of the parameter, configuration: The akka configuration for migrator",
+              "description": "configuration lower-cased is a substring of the parameter, configuration: The akka configuration for migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8952,7 +8901,7 @@
             },
             {
               "name": "configuration_l_not_in",
-              "description": "configuration lowercased is not a substring of the parameter, configuration: The akka configuration for migrator",
+              "description": "configuration lower-cased is not a substring of the parameter, configuration: The akka configuration for migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8962,7 +8911,7 @@
             },
             {
               "name": "configuration_l_contains",
-              "description": "configuration lowercased contains the parameter as substring, configuration: The akka configuration for migrator",
+              "description": "configuration lower-cased contains the parameter as substring, configuration: The akka configuration for migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8972,7 +8921,7 @@
             },
             {
               "name": "configuration_l_not_contains",
-              "description": "configuration lowercased doesn't contain the parameter as substring, configuration: The akka configuration for migrator",
+              "description": "configuration lower-cased doesn't contain the parameter as substring, configuration: The akka configuration for migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8982,7 +8931,7 @@
             },
             {
               "name": "configuration_l_starts_with",
-              "description": "configuration lowercased starts with the parameter value, configuration: The akka configuration for migrator",
+              "description": "configuration lower-cased starts with the parameter value, configuration: The akka configuration for migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -8992,7 +8941,7 @@
             },
             {
               "name": "configuration_l_not_starts_with",
-              "description": "configuration lowercased doesn't start with the parameter value, configuration: The akka configuration for migrator",
+              "description": "configuration lower-cased doesn't start with the parameter value, configuration: The akka configuration for migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9002,7 +8951,7 @@
             },
             {
               "name": "configuration_l_ends_with",
-              "description": "configuration lowercased ends with the parameter value, configuration: The akka configuration for migrator",
+              "description": "configuration lower-cased ends with the parameter value, configuration: The akka configuration for migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9012,7 +8961,7 @@
             },
             {
               "name": "configuration_l_not_ends_with",
-              "description": "configuration lowercased doesn't end with the parameter value, configuration: The akka configuration for migrator",
+              "description": "configuration lower-cased doesn't end with the parameter value, configuration: The akka configuration for migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9122,7 +9071,7 @@
             },
             {
               "name": "name_l",
-              "description": "name lowercased equals the parameter, name: The human readable migrator template name",
+              "description": "name lower-cased equals the parameter, name: The human readable migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9132,7 +9081,7 @@
             },
             {
               "name": "name_l_not",
-              "description": "name lowercased doesn't equal the parameter, name: The human readable migrator template name",
+              "description": "name lower-cased doesn't equal the parameter, name: The human readable migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9142,7 +9091,7 @@
             },
             {
               "name": "name_l_in",
-              "description": "name lowercased is a substring of the parameter, name: The human readable migrator template name",
+              "description": "name lower-cased is a substring of the parameter, name: The human readable migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9152,7 +9101,7 @@
             },
             {
               "name": "name_l_not_in",
-              "description": "name lowercased is not a substring of the parameter, name: The human readable migrator template name",
+              "description": "name lower-cased is not a substring of the parameter, name: The human readable migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9162,7 +9111,7 @@
             },
             {
               "name": "name_l_contains",
-              "description": "name lowercased contains the parameter as substring, name: The human readable migrator template name",
+              "description": "name lower-cased contains the parameter as substring, name: The human readable migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9172,7 +9121,7 @@
             },
             {
               "name": "name_l_not_contains",
-              "description": "name lowercased doesn't contain the parameter as substring, name: The human readable migrator template name",
+              "description": "name lower-cased doesn't contain the parameter as substring, name: The human readable migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9182,7 +9131,7 @@
             },
             {
               "name": "name_l_starts_with",
-              "description": "name lowercased starts with the parameter value, name: The human readable migrator template name",
+              "description": "name lower-cased starts with the parameter value, name: The human readable migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9192,7 +9141,7 @@
             },
             {
               "name": "name_l_not_starts_with",
-              "description": "name lowercased doesn't start with the parameter value, name: The human readable migrator template name",
+              "description": "name lower-cased doesn't start with the parameter value, name: The human readable migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9202,7 +9151,7 @@
             },
             {
               "name": "name_l_ends_with",
-              "description": "name lowercased ends with the parameter value, name: The human readable migrator template name",
+              "description": "name lower-cased ends with the parameter value, name: The human readable migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9212,7 +9161,7 @@
             },
             {
               "name": "name_l_not_ends_with",
-              "description": "name lowercased doesn't end with the parameter value, name: The human readable migrator template name",
+              "description": "name lower-cased doesn't end with the parameter value, name: The human readable migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9322,7 +9271,7 @@
             },
             {
               "name": "notes_l",
-              "description": "notes lowercased equals the parameter, notes: The migrator description for other users",
+              "description": "notes lower-cased equals the parameter, notes: The migrator description for other users",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9332,7 +9281,7 @@
             },
             {
               "name": "notes_l_not",
-              "description": "notes lowercased doesn't equal the parameter, notes: The migrator description for other users",
+              "description": "notes lower-cased doesn't equal the parameter, notes: The migrator description for other users",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9342,7 +9291,7 @@
             },
             {
               "name": "notes_l_in",
-              "description": "notes lowercased is a substring of the parameter, notes: The migrator description for other users",
+              "description": "notes lower-cased is a substring of the parameter, notes: The migrator description for other users",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9352,7 +9301,7 @@
             },
             {
               "name": "notes_l_not_in",
-              "description": "notes lowercased is not a substring of the parameter, notes: The migrator description for other users",
+              "description": "notes lower-cased is not a substring of the parameter, notes: The migrator description for other users",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9362,7 +9311,7 @@
             },
             {
               "name": "notes_l_contains",
-              "description": "notes lowercased contains the parameter as substring, notes: The migrator description for other users",
+              "description": "notes lower-cased contains the parameter as substring, notes: The migrator description for other users",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9372,7 +9321,7 @@
             },
             {
               "name": "notes_l_not_contains",
-              "description": "notes lowercased doesn't contain the parameter as substring, notes: The migrator description for other users",
+              "description": "notes lower-cased doesn't contain the parameter as substring, notes: The migrator description for other users",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9382,7 +9331,7 @@
             },
             {
               "name": "notes_l_starts_with",
-              "description": "notes lowercased starts with the parameter value, notes: The migrator description for other users",
+              "description": "notes lower-cased starts with the parameter value, notes: The migrator description for other users",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9392,7 +9341,7 @@
             },
             {
               "name": "notes_l_not_starts_with",
-              "description": "notes lowercased doesn't start with the parameter value, notes: The migrator description for other users",
+              "description": "notes lower-cased doesn't start with the parameter value, notes: The migrator description for other users",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9402,7 +9351,7 @@
             },
             {
               "name": "notes_l_ends_with",
-              "description": "notes lowercased ends with the parameter value, notes: The migrator description for other users",
+              "description": "notes lower-cased ends with the parameter value, notes: The migrator description for other users",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9412,7 +9361,7 @@
             },
             {
               "name": "notes_l_not_ends_with",
-              "description": "notes lowercased doesn't end with the parameter value, notes: The migrator description for other users",
+              "description": "notes lower-cased doesn't end with the parameter value, notes: The migrator description for other users",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9486,6 +9435,77 @@
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "KlusterKiteNodeApi_MigratorTemplate_Sort",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "code_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "code_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "configuration_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "configuration_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "notes_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "notes_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "priority_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "priority_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
           "kind": "INTERFACE",
           "name": "IKlusterKiteNodeApi_CompatibleTemplate_Connection",
           "description": "The list of connected KlusterKiteNodeApi_CompatibleTemplate\n The compatible node template",
@@ -9520,7 +9540,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -9561,7 +9581,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -9662,7 +9682,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -9671,65 +9691,6 @@
               "ofType": null
             }
           ]
-        },
-        {
-          "kind": "ENUM",
-          "name": "KlusterKiteNodeApi_CompatibleTemplate_Sort",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "id_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "compatibleConfigurationId_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "compatibleConfigurationId_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "configurationId_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "configurationId_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "templateCode_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "templateCode_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
         },
         {
           "kind": "INPUT_OBJECT",
@@ -10039,7 +10000,7 @@
             },
             {
               "name": "templateCode_l",
-              "description": "templateCode lowercased equals the parameter, templateCode: the template code",
+              "description": "templateCode lower-cased equals the parameter, templateCode: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -10049,7 +10010,7 @@
             },
             {
               "name": "templateCode_l_not",
-              "description": "templateCode lowercased doesn't equal the parameter, templateCode: the template code",
+              "description": "templateCode lower-cased doesn't equal the parameter, templateCode: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -10059,7 +10020,7 @@
             },
             {
               "name": "templateCode_l_in",
-              "description": "templateCode lowercased is a substring of the parameter, templateCode: the template code",
+              "description": "templateCode lower-cased is a substring of the parameter, templateCode: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -10069,7 +10030,7 @@
             },
             {
               "name": "templateCode_l_not_in",
-              "description": "templateCode lowercased is not a substring of the parameter, templateCode: the template code",
+              "description": "templateCode lower-cased is not a substring of the parameter, templateCode: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -10079,7 +10040,7 @@
             },
             {
               "name": "templateCode_l_contains",
-              "description": "templateCode lowercased contains the parameter as substring, templateCode: the template code",
+              "description": "templateCode lower-cased contains the parameter as substring, templateCode: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -10089,7 +10050,7 @@
             },
             {
               "name": "templateCode_l_not_contains",
-              "description": "templateCode lowercased doesn't contain the parameter as substring, templateCode: the template code",
+              "description": "templateCode lower-cased doesn't contain the parameter as substring, templateCode: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -10099,7 +10060,7 @@
             },
             {
               "name": "templateCode_l_starts_with",
-              "description": "templateCode lowercased starts with the parameter value, templateCode: the template code",
+              "description": "templateCode lower-cased starts with the parameter value, templateCode: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -10109,7 +10070,7 @@
             },
             {
               "name": "templateCode_l_not_starts_with",
-              "description": "templateCode lowercased doesn't start with the parameter value, templateCode: the template code",
+              "description": "templateCode lower-cased doesn't start with the parameter value, templateCode: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -10119,7 +10080,7 @@
             },
             {
               "name": "templateCode_l_ends_with",
-              "description": "templateCode lowercased ends with the parameter value, templateCode: the template code",
+              "description": "templateCode lower-cased ends with the parameter value, templateCode: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -10129,7 +10090,7 @@
             },
             {
               "name": "templateCode_l_not_ends_with",
-              "description": "templateCode lowercased doesn't end with the parameter value, templateCode: the template code",
+              "description": "templateCode lower-cased doesn't end with the parameter value, templateCode: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -10140,6 +10101,65 @@
           ],
           "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "KlusterKiteNodeApi_CompatibleTemplate_Sort",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "id_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "compatibleConfigurationId_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "compatibleConfigurationId_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "configurationId_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "configurationId_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "templateCode_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "templateCode_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -10177,7 +10197,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -10218,7 +10238,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -10383,7 +10403,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -10395,7 +10415,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -10451,7 +10471,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -10520,209 +10540,6 @@
             {
               "name": "CanceledToConfiguration",
               "description": "The migration to this configuration was canceled",
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "ENUM",
-          "name": "KlusterKiteNodeApi_MigrationLogRecord_Sort",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "id_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "type_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "type_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "migrationId_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "migrationId_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "configurationId_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "configurationId_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "migratorTemplateCode_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "migratorTemplateCode_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "migratorTemplateName_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "migratorTemplateName_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "migratorTypeName_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "migratorTypeName_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "migratorName_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "migratorName_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "resourceCode_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "resourceCode_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "resourceName_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "resourceName_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "started_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "started_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "finished_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "finished_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "sourcePoint_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "sourcePoint_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "destinationPoint_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "destinationPoint_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "message_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "message_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "errorStackTrace_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "errorStackTrace_desc",
-              "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -11057,7 +10874,7 @@
             },
             {
               "name": "migratorTemplateCode_l",
-              "description": "migratorTemplateCode lowercased equals the parameter, migratorTemplateCode: the migrator template code",
+              "description": "migratorTemplateCode lower-cased equals the parameter, migratorTemplateCode: the migrator template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11067,7 +10884,7 @@
             },
             {
               "name": "migratorTemplateCode_l_not",
-              "description": "migratorTemplateCode lowercased doesn't equal the parameter, migratorTemplateCode: the migrator template code",
+              "description": "migratorTemplateCode lower-cased doesn't equal the parameter, migratorTemplateCode: the migrator template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11077,7 +10894,7 @@
             },
             {
               "name": "migratorTemplateCode_l_in",
-              "description": "migratorTemplateCode lowercased is a substring of the parameter, migratorTemplateCode: the migrator template code",
+              "description": "migratorTemplateCode lower-cased is a substring of the parameter, migratorTemplateCode: the migrator template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11087,7 +10904,7 @@
             },
             {
               "name": "migratorTemplateCode_l_not_in",
-              "description": "migratorTemplateCode lowercased is not a substring of the parameter, migratorTemplateCode: the migrator template code",
+              "description": "migratorTemplateCode lower-cased is not a substring of the parameter, migratorTemplateCode: the migrator template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11097,7 +10914,7 @@
             },
             {
               "name": "migratorTemplateCode_l_contains",
-              "description": "migratorTemplateCode lowercased contains the parameter as substring, migratorTemplateCode: the migrator template code",
+              "description": "migratorTemplateCode lower-cased contains the parameter as substring, migratorTemplateCode: the migrator template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11107,7 +10924,7 @@
             },
             {
               "name": "migratorTemplateCode_l_not_contains",
-              "description": "migratorTemplateCode lowercased doesn't contain the parameter as substring, migratorTemplateCode: the migrator template code",
+              "description": "migratorTemplateCode lower-cased doesn't contain the parameter as substring, migratorTemplateCode: the migrator template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11117,7 +10934,7 @@
             },
             {
               "name": "migratorTemplateCode_l_starts_with",
-              "description": "migratorTemplateCode lowercased starts with the parameter value, migratorTemplateCode: the migrator template code",
+              "description": "migratorTemplateCode lower-cased starts with the parameter value, migratorTemplateCode: the migrator template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11127,7 +10944,7 @@
             },
             {
               "name": "migratorTemplateCode_l_not_starts_with",
-              "description": "migratorTemplateCode lowercased doesn't start with the parameter value, migratorTemplateCode: the migrator template code",
+              "description": "migratorTemplateCode lower-cased doesn't start with the parameter value, migratorTemplateCode: the migrator template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11137,7 +10954,7 @@
             },
             {
               "name": "migratorTemplateCode_l_ends_with",
-              "description": "migratorTemplateCode lowercased ends with the parameter value, migratorTemplateCode: the migrator template code",
+              "description": "migratorTemplateCode lower-cased ends with the parameter value, migratorTemplateCode: the migrator template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11147,7 +10964,7 @@
             },
             {
               "name": "migratorTemplateCode_l_not_ends_with",
-              "description": "migratorTemplateCode lowercased doesn't end with the parameter value, migratorTemplateCode: the migrator template code",
+              "description": "migratorTemplateCode lower-cased doesn't end with the parameter value, migratorTemplateCode: the migrator template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11257,7 +11074,7 @@
             },
             {
               "name": "migratorTemplateName_l",
-              "description": "migratorTemplateName lowercased equals the parameter, migratorTemplateName: the migrator template name",
+              "description": "migratorTemplateName lower-cased equals the parameter, migratorTemplateName: the migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11267,7 +11084,7 @@
             },
             {
               "name": "migratorTemplateName_l_not",
-              "description": "migratorTemplateName lowercased doesn't equal the parameter, migratorTemplateName: the migrator template name",
+              "description": "migratorTemplateName lower-cased doesn't equal the parameter, migratorTemplateName: the migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11277,7 +11094,7 @@
             },
             {
               "name": "migratorTemplateName_l_in",
-              "description": "migratorTemplateName lowercased is a substring of the parameter, migratorTemplateName: the migrator template name",
+              "description": "migratorTemplateName lower-cased is a substring of the parameter, migratorTemplateName: the migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11287,7 +11104,7 @@
             },
             {
               "name": "migratorTemplateName_l_not_in",
-              "description": "migratorTemplateName lowercased is not a substring of the parameter, migratorTemplateName: the migrator template name",
+              "description": "migratorTemplateName lower-cased is not a substring of the parameter, migratorTemplateName: the migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11297,7 +11114,7 @@
             },
             {
               "name": "migratorTemplateName_l_contains",
-              "description": "migratorTemplateName lowercased contains the parameter as substring, migratorTemplateName: the migrator template name",
+              "description": "migratorTemplateName lower-cased contains the parameter as substring, migratorTemplateName: the migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11307,7 +11124,7 @@
             },
             {
               "name": "migratorTemplateName_l_not_contains",
-              "description": "migratorTemplateName lowercased doesn't contain the parameter as substring, migratorTemplateName: the migrator template name",
+              "description": "migratorTemplateName lower-cased doesn't contain the parameter as substring, migratorTemplateName: the migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11317,7 +11134,7 @@
             },
             {
               "name": "migratorTemplateName_l_starts_with",
-              "description": "migratorTemplateName lowercased starts with the parameter value, migratorTemplateName: the migrator template name",
+              "description": "migratorTemplateName lower-cased starts with the parameter value, migratorTemplateName: the migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11327,7 +11144,7 @@
             },
             {
               "name": "migratorTemplateName_l_not_starts_with",
-              "description": "migratorTemplateName lowercased doesn't start with the parameter value, migratorTemplateName: the migrator template name",
+              "description": "migratorTemplateName lower-cased doesn't start with the parameter value, migratorTemplateName: the migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11337,7 +11154,7 @@
             },
             {
               "name": "migratorTemplateName_l_ends_with",
-              "description": "migratorTemplateName lowercased ends with the parameter value, migratorTemplateName: the migrator template name",
+              "description": "migratorTemplateName lower-cased ends with the parameter value, migratorTemplateName: the migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11347,7 +11164,7 @@
             },
             {
               "name": "migratorTemplateName_l_not_ends_with",
-              "description": "migratorTemplateName lowercased doesn't end with the parameter value, migratorTemplateName: the migrator template name",
+              "description": "migratorTemplateName lower-cased doesn't end with the parameter value, migratorTemplateName: the migrator template name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11457,7 +11274,7 @@
             },
             {
               "name": "migratorTypeName_l",
-              "description": "migratorTypeName lowercased equals the parameter, migratorTypeName: the migrator type name",
+              "description": "migratorTypeName lower-cased equals the parameter, migratorTypeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11467,7 +11284,7 @@
             },
             {
               "name": "migratorTypeName_l_not",
-              "description": "migratorTypeName lowercased doesn't equal the parameter, migratorTypeName: the migrator type name",
+              "description": "migratorTypeName lower-cased doesn't equal the parameter, migratorTypeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11477,7 +11294,7 @@
             },
             {
               "name": "migratorTypeName_l_in",
-              "description": "migratorTypeName lowercased is a substring of the parameter, migratorTypeName: the migrator type name",
+              "description": "migratorTypeName lower-cased is a substring of the parameter, migratorTypeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11487,7 +11304,7 @@
             },
             {
               "name": "migratorTypeName_l_not_in",
-              "description": "migratorTypeName lowercased is not a substring of the parameter, migratorTypeName: the migrator type name",
+              "description": "migratorTypeName lower-cased is not a substring of the parameter, migratorTypeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11497,7 +11314,7 @@
             },
             {
               "name": "migratorTypeName_l_contains",
-              "description": "migratorTypeName lowercased contains the parameter as substring, migratorTypeName: the migrator type name",
+              "description": "migratorTypeName lower-cased contains the parameter as substring, migratorTypeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11507,7 +11324,7 @@
             },
             {
               "name": "migratorTypeName_l_not_contains",
-              "description": "migratorTypeName lowercased doesn't contain the parameter as substring, migratorTypeName: the migrator type name",
+              "description": "migratorTypeName lower-cased doesn't contain the parameter as substring, migratorTypeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11517,7 +11334,7 @@
             },
             {
               "name": "migratorTypeName_l_starts_with",
-              "description": "migratorTypeName lowercased starts with the parameter value, migratorTypeName: the migrator type name",
+              "description": "migratorTypeName lower-cased starts with the parameter value, migratorTypeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11527,7 +11344,7 @@
             },
             {
               "name": "migratorTypeName_l_not_starts_with",
-              "description": "migratorTypeName lowercased doesn't start with the parameter value, migratorTypeName: the migrator type name",
+              "description": "migratorTypeName lower-cased doesn't start with the parameter value, migratorTypeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11537,7 +11354,7 @@
             },
             {
               "name": "migratorTypeName_l_ends_with",
-              "description": "migratorTypeName lowercased ends with the parameter value, migratorTypeName: the migrator type name",
+              "description": "migratorTypeName lower-cased ends with the parameter value, migratorTypeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11547,7 +11364,7 @@
             },
             {
               "name": "migratorTypeName_l_not_ends_with",
-              "description": "migratorTypeName lowercased doesn't end with the parameter value, migratorTypeName: the migrator type name",
+              "description": "migratorTypeName lower-cased doesn't end with the parameter value, migratorTypeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11657,7 +11474,7 @@
             },
             {
               "name": "migratorName_l",
-              "description": "migratorName lowercased equals the parameter, migratorName: the migrator name",
+              "description": "migratorName lower-cased equals the parameter, migratorName: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11667,7 +11484,7 @@
             },
             {
               "name": "migratorName_l_not",
-              "description": "migratorName lowercased doesn't equal the parameter, migratorName: the migrator name",
+              "description": "migratorName lower-cased doesn't equal the parameter, migratorName: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11677,7 +11494,7 @@
             },
             {
               "name": "migratorName_l_in",
-              "description": "migratorName lowercased is a substring of the parameter, migratorName: the migrator name",
+              "description": "migratorName lower-cased is a substring of the parameter, migratorName: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11687,7 +11504,7 @@
             },
             {
               "name": "migratorName_l_not_in",
-              "description": "migratorName lowercased is not a substring of the parameter, migratorName: the migrator name",
+              "description": "migratorName lower-cased is not a substring of the parameter, migratorName: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11697,7 +11514,7 @@
             },
             {
               "name": "migratorName_l_contains",
-              "description": "migratorName lowercased contains the parameter as substring, migratorName: the migrator name",
+              "description": "migratorName lower-cased contains the parameter as substring, migratorName: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11707,7 +11524,7 @@
             },
             {
               "name": "migratorName_l_not_contains",
-              "description": "migratorName lowercased doesn't contain the parameter as substring, migratorName: the migrator name",
+              "description": "migratorName lower-cased doesn't contain the parameter as substring, migratorName: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11717,7 +11534,7 @@
             },
             {
               "name": "migratorName_l_starts_with",
-              "description": "migratorName lowercased starts with the parameter value, migratorName: the migrator name",
+              "description": "migratorName lower-cased starts with the parameter value, migratorName: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11727,7 +11544,7 @@
             },
             {
               "name": "migratorName_l_not_starts_with",
-              "description": "migratorName lowercased doesn't start with the parameter value, migratorName: the migrator name",
+              "description": "migratorName lower-cased doesn't start with the parameter value, migratorName: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11737,7 +11554,7 @@
             },
             {
               "name": "migratorName_l_ends_with",
-              "description": "migratorName lowercased ends with the parameter value, migratorName: the migrator name",
+              "description": "migratorName lower-cased ends with the parameter value, migratorName: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11747,7 +11564,7 @@
             },
             {
               "name": "migratorName_l_not_ends_with",
-              "description": "migratorName lowercased doesn't end with the parameter value, migratorName: the migrator name",
+              "description": "migratorName lower-cased doesn't end with the parameter value, migratorName: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11857,7 +11674,7 @@
             },
             {
               "name": "resourceCode_l",
-              "description": "resourceCode lowercased equals the parameter, resourceCode: the resource code",
+              "description": "resourceCode lower-cased equals the parameter, resourceCode: the resource code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11867,7 +11684,7 @@
             },
             {
               "name": "resourceCode_l_not",
-              "description": "resourceCode lowercased doesn't equal the parameter, resourceCode: the resource code",
+              "description": "resourceCode lower-cased doesn't equal the parameter, resourceCode: the resource code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11877,7 +11694,7 @@
             },
             {
               "name": "resourceCode_l_in",
-              "description": "resourceCode lowercased is a substring of the parameter, resourceCode: the resource code",
+              "description": "resourceCode lower-cased is a substring of the parameter, resourceCode: the resource code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11887,7 +11704,7 @@
             },
             {
               "name": "resourceCode_l_not_in",
-              "description": "resourceCode lowercased is not a substring of the parameter, resourceCode: the resource code",
+              "description": "resourceCode lower-cased is not a substring of the parameter, resourceCode: the resource code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11897,7 +11714,7 @@
             },
             {
               "name": "resourceCode_l_contains",
-              "description": "resourceCode lowercased contains the parameter as substring, resourceCode: the resource code",
+              "description": "resourceCode lower-cased contains the parameter as substring, resourceCode: the resource code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11907,7 +11724,7 @@
             },
             {
               "name": "resourceCode_l_not_contains",
-              "description": "resourceCode lowercased doesn't contain the parameter as substring, resourceCode: the resource code",
+              "description": "resourceCode lower-cased doesn't contain the parameter as substring, resourceCode: the resource code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11917,7 +11734,7 @@
             },
             {
               "name": "resourceCode_l_starts_with",
-              "description": "resourceCode lowercased starts with the parameter value, resourceCode: the resource code",
+              "description": "resourceCode lower-cased starts with the parameter value, resourceCode: the resource code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11927,7 +11744,7 @@
             },
             {
               "name": "resourceCode_l_not_starts_with",
-              "description": "resourceCode lowercased doesn't start with the parameter value, resourceCode: the resource code",
+              "description": "resourceCode lower-cased doesn't start with the parameter value, resourceCode: the resource code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11937,7 +11754,7 @@
             },
             {
               "name": "resourceCode_l_ends_with",
-              "description": "resourceCode lowercased ends with the parameter value, resourceCode: the resource code",
+              "description": "resourceCode lower-cased ends with the parameter value, resourceCode: the resource code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11947,7 +11764,7 @@
             },
             {
               "name": "resourceCode_l_not_ends_with",
-              "description": "resourceCode lowercased doesn't end with the parameter value, resourceCode: the resource code",
+              "description": "resourceCode lower-cased doesn't end with the parameter value, resourceCode: the resource code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12057,7 +11874,7 @@
             },
             {
               "name": "resourceName_l",
-              "description": "resourceName lowercased equals the parameter, resourceName: the resource name",
+              "description": "resourceName lower-cased equals the parameter, resourceName: the resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12067,7 +11884,7 @@
             },
             {
               "name": "resourceName_l_not",
-              "description": "resourceName lowercased doesn't equal the parameter, resourceName: the resource name",
+              "description": "resourceName lower-cased doesn't equal the parameter, resourceName: the resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12077,7 +11894,7 @@
             },
             {
               "name": "resourceName_l_in",
-              "description": "resourceName lowercased is a substring of the parameter, resourceName: the resource name",
+              "description": "resourceName lower-cased is a substring of the parameter, resourceName: the resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12087,7 +11904,7 @@
             },
             {
               "name": "resourceName_l_not_in",
-              "description": "resourceName lowercased is not a substring of the parameter, resourceName: the resource name",
+              "description": "resourceName lower-cased is not a substring of the parameter, resourceName: the resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12097,7 +11914,7 @@
             },
             {
               "name": "resourceName_l_contains",
-              "description": "resourceName lowercased contains the parameter as substring, resourceName: the resource name",
+              "description": "resourceName lower-cased contains the parameter as substring, resourceName: the resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12107,7 +11924,7 @@
             },
             {
               "name": "resourceName_l_not_contains",
-              "description": "resourceName lowercased doesn't contain the parameter as substring, resourceName: the resource name",
+              "description": "resourceName lower-cased doesn't contain the parameter as substring, resourceName: the resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12117,7 +11934,7 @@
             },
             {
               "name": "resourceName_l_starts_with",
-              "description": "resourceName lowercased starts with the parameter value, resourceName: the resource name",
+              "description": "resourceName lower-cased starts with the parameter value, resourceName: the resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12127,7 +11944,7 @@
             },
             {
               "name": "resourceName_l_not_starts_with",
-              "description": "resourceName lowercased doesn't start with the parameter value, resourceName: the resource name",
+              "description": "resourceName lower-cased doesn't start with the parameter value, resourceName: the resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12137,7 +11954,7 @@
             },
             {
               "name": "resourceName_l_ends_with",
-              "description": "resourceName lowercased ends with the parameter value, resourceName: the resource name",
+              "description": "resourceName lower-cased ends with the parameter value, resourceName: the resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12147,7 +11964,7 @@
             },
             {
               "name": "resourceName_l_not_ends_with",
-              "description": "resourceName lowercased doesn't end with the parameter value, resourceName: the resource name",
+              "description": "resourceName lower-cased doesn't end with the parameter value, resourceName: the resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12160,7 +11977,7 @@
               "description": "started exactly equals to the parameter, started: the operation execution start time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -12170,7 +11987,7 @@
               "description": "started not equals to the parameter, started: the operation execution start time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -12180,7 +11997,7 @@
               "description": "started is less then the parameter, started: the operation execution start time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -12190,7 +12007,7 @@
               "description": "started is less then or equal to the parameter, started: the operation execution start time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -12200,7 +12017,7 @@
               "description": "started is greater then the parameter, started: the operation execution start time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -12210,7 +12027,7 @@
               "description": "started is greater then or equal to the parameter, started: the operation execution start time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -12220,7 +12037,7 @@
               "description": "finished exactly equals to the parameter, finished: the operation execution finish time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -12230,7 +12047,7 @@
               "description": "finished not equals to the parameter, finished: the operation execution finish time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -12240,7 +12057,7 @@
               "description": "finished is less then the parameter, finished: the operation execution finish time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -12250,7 +12067,7 @@
               "description": "finished is less then or equal to the parameter, finished: the operation execution finish time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -12260,7 +12077,7 @@
               "description": "finished is greater then the parameter, finished: the operation execution finish time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -12270,7 +12087,7 @@
               "description": "finished is greater then or equal to the parameter, finished: the operation execution finish time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -12377,7 +12194,7 @@
             },
             {
               "name": "sourcePoint_l",
-              "description": "sourcePoint lowercased equals the parameter, sourcePoint: the source migration point",
+              "description": "sourcePoint lower-cased equals the parameter, sourcePoint: the source migration point",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12387,7 +12204,7 @@
             },
             {
               "name": "sourcePoint_l_not",
-              "description": "sourcePoint lowercased doesn't equal the parameter, sourcePoint: the source migration point",
+              "description": "sourcePoint lower-cased doesn't equal the parameter, sourcePoint: the source migration point",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12397,7 +12214,7 @@
             },
             {
               "name": "sourcePoint_l_in",
-              "description": "sourcePoint lowercased is a substring of the parameter, sourcePoint: the source migration point",
+              "description": "sourcePoint lower-cased is a substring of the parameter, sourcePoint: the source migration point",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12407,7 +12224,7 @@
             },
             {
               "name": "sourcePoint_l_not_in",
-              "description": "sourcePoint lowercased is not a substring of the parameter, sourcePoint: the source migration point",
+              "description": "sourcePoint lower-cased is not a substring of the parameter, sourcePoint: the source migration point",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12417,7 +12234,7 @@
             },
             {
               "name": "sourcePoint_l_contains",
-              "description": "sourcePoint lowercased contains the parameter as substring, sourcePoint: the source migration point",
+              "description": "sourcePoint lower-cased contains the parameter as substring, sourcePoint: the source migration point",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12427,7 +12244,7 @@
             },
             {
               "name": "sourcePoint_l_not_contains",
-              "description": "sourcePoint lowercased doesn't contain the parameter as substring, sourcePoint: the source migration point",
+              "description": "sourcePoint lower-cased doesn't contain the parameter as substring, sourcePoint: the source migration point",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12437,7 +12254,7 @@
             },
             {
               "name": "sourcePoint_l_starts_with",
-              "description": "sourcePoint lowercased starts with the parameter value, sourcePoint: the source migration point",
+              "description": "sourcePoint lower-cased starts with the parameter value, sourcePoint: the source migration point",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12447,7 +12264,7 @@
             },
             {
               "name": "sourcePoint_l_not_starts_with",
-              "description": "sourcePoint lowercased doesn't start with the parameter value, sourcePoint: the source migration point",
+              "description": "sourcePoint lower-cased doesn't start with the parameter value, sourcePoint: the source migration point",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12457,7 +12274,7 @@
             },
             {
               "name": "sourcePoint_l_ends_with",
-              "description": "sourcePoint lowercased ends with the parameter value, sourcePoint: the source migration point",
+              "description": "sourcePoint lower-cased ends with the parameter value, sourcePoint: the source migration point",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12467,7 +12284,7 @@
             },
             {
               "name": "sourcePoint_l_not_ends_with",
-              "description": "sourcePoint lowercased doesn't end with the parameter value, sourcePoint: the source migration point",
+              "description": "sourcePoint lower-cased doesn't end with the parameter value, sourcePoint: the source migration point",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12577,7 +12394,7 @@
             },
             {
               "name": "destinationPoint_l",
-              "description": "destinationPoint lowercased equals the parameter, destinationPoint: the destination migration point",
+              "description": "destinationPoint lower-cased equals the parameter, destinationPoint: the destination migration point",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12587,7 +12404,7 @@
             },
             {
               "name": "destinationPoint_l_not",
-              "description": "destinationPoint lowercased doesn't equal the parameter, destinationPoint: the destination migration point",
+              "description": "destinationPoint lower-cased doesn't equal the parameter, destinationPoint: the destination migration point",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12597,7 +12414,7 @@
             },
             {
               "name": "destinationPoint_l_in",
-              "description": "destinationPoint lowercased is a substring of the parameter, destinationPoint: the destination migration point",
+              "description": "destinationPoint lower-cased is a substring of the parameter, destinationPoint: the destination migration point",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12607,7 +12424,7 @@
             },
             {
               "name": "destinationPoint_l_not_in",
-              "description": "destinationPoint lowercased is not a substring of the parameter, destinationPoint: the destination migration point",
+              "description": "destinationPoint lower-cased is not a substring of the parameter, destinationPoint: the destination migration point",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12617,7 +12434,7 @@
             },
             {
               "name": "destinationPoint_l_contains",
-              "description": "destinationPoint lowercased contains the parameter as substring, destinationPoint: the destination migration point",
+              "description": "destinationPoint lower-cased contains the parameter as substring, destinationPoint: the destination migration point",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12627,7 +12444,7 @@
             },
             {
               "name": "destinationPoint_l_not_contains",
-              "description": "destinationPoint lowercased doesn't contain the parameter as substring, destinationPoint: the destination migration point",
+              "description": "destinationPoint lower-cased doesn't contain the parameter as substring, destinationPoint: the destination migration point",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12637,7 +12454,7 @@
             },
             {
               "name": "destinationPoint_l_starts_with",
-              "description": "destinationPoint lowercased starts with the parameter value, destinationPoint: the destination migration point",
+              "description": "destinationPoint lower-cased starts with the parameter value, destinationPoint: the destination migration point",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12647,7 +12464,7 @@
             },
             {
               "name": "destinationPoint_l_not_starts_with",
-              "description": "destinationPoint lowercased doesn't start with the parameter value, destinationPoint: the destination migration point",
+              "description": "destinationPoint lower-cased doesn't start with the parameter value, destinationPoint: the destination migration point",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12657,7 +12474,7 @@
             },
             {
               "name": "destinationPoint_l_ends_with",
-              "description": "destinationPoint lowercased ends with the parameter value, destinationPoint: the destination migration point",
+              "description": "destinationPoint lower-cased ends with the parameter value, destinationPoint: the destination migration point",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12667,7 +12484,7 @@
             },
             {
               "name": "destinationPoint_l_not_ends_with",
-              "description": "destinationPoint lowercased doesn't end with the parameter value, destinationPoint: the destination migration point",
+              "description": "destinationPoint lower-cased doesn't end with the parameter value, destinationPoint: the destination migration point",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12777,7 +12594,7 @@
             },
             {
               "name": "message_l",
-              "description": "message lowercased equals the parameter, message: the message",
+              "description": "message lower-cased equals the parameter, message: the message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12787,7 +12604,7 @@
             },
             {
               "name": "message_l_not",
-              "description": "message lowercased doesn't equal the parameter, message: the message",
+              "description": "message lower-cased doesn't equal the parameter, message: the message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12797,7 +12614,7 @@
             },
             {
               "name": "message_l_in",
-              "description": "message lowercased is a substring of the parameter, message: the message",
+              "description": "message lower-cased is a substring of the parameter, message: the message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12807,7 +12624,7 @@
             },
             {
               "name": "message_l_not_in",
-              "description": "message lowercased is not a substring of the parameter, message: the message",
+              "description": "message lower-cased is not a substring of the parameter, message: the message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12817,7 +12634,7 @@
             },
             {
               "name": "message_l_contains",
-              "description": "message lowercased contains the parameter as substring, message: the message",
+              "description": "message lower-cased contains the parameter as substring, message: the message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12827,7 +12644,7 @@
             },
             {
               "name": "message_l_not_contains",
-              "description": "message lowercased doesn't contain the parameter as substring, message: the message",
+              "description": "message lower-cased doesn't contain the parameter as substring, message: the message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12837,7 +12654,7 @@
             },
             {
               "name": "message_l_starts_with",
-              "description": "message lowercased starts with the parameter value, message: the message",
+              "description": "message lower-cased starts with the parameter value, message: the message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12847,7 +12664,7 @@
             },
             {
               "name": "message_l_not_starts_with",
-              "description": "message lowercased doesn't start with the parameter value, message: the message",
+              "description": "message lower-cased doesn't start with the parameter value, message: the message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12857,7 +12674,7 @@
             },
             {
               "name": "message_l_ends_with",
-              "description": "message lowercased ends with the parameter value, message: the message",
+              "description": "message lower-cased ends with the parameter value, message: the message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12867,7 +12684,7 @@
             },
             {
               "name": "message_l_not_ends_with",
-              "description": "message lowercased doesn't end with the parameter value, message: the message",
+              "description": "message lower-cased doesn't end with the parameter value, message: the message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12977,7 +12794,7 @@
             },
             {
               "name": "errorStackTrace_l",
-              "description": "errorStackTrace lowercased equals the parameter, errorStackTrace: the error stack trace",
+              "description": "errorStackTrace lower-cased equals the parameter, errorStackTrace: the error stack trace",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12987,7 +12804,7 @@
             },
             {
               "name": "errorStackTrace_l_not",
-              "description": "errorStackTrace lowercased doesn't equal the parameter, errorStackTrace: the error stack trace",
+              "description": "errorStackTrace lower-cased doesn't equal the parameter, errorStackTrace: the error stack trace",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12997,7 +12814,7 @@
             },
             {
               "name": "errorStackTrace_l_in",
-              "description": "errorStackTrace lowercased is a substring of the parameter, errorStackTrace: the error stack trace",
+              "description": "errorStackTrace lower-cased is a substring of the parameter, errorStackTrace: the error stack trace",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -13007,7 +12824,7 @@
             },
             {
               "name": "errorStackTrace_l_not_in",
-              "description": "errorStackTrace lowercased is not a substring of the parameter, errorStackTrace: the error stack trace",
+              "description": "errorStackTrace lower-cased is not a substring of the parameter, errorStackTrace: the error stack trace",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -13017,7 +12834,7 @@
             },
             {
               "name": "errorStackTrace_l_contains",
-              "description": "errorStackTrace lowercased contains the parameter as substring, errorStackTrace: the error stack trace",
+              "description": "errorStackTrace lower-cased contains the parameter as substring, errorStackTrace: the error stack trace",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -13027,7 +12844,7 @@
             },
             {
               "name": "errorStackTrace_l_not_contains",
-              "description": "errorStackTrace lowercased doesn't contain the parameter as substring, errorStackTrace: the error stack trace",
+              "description": "errorStackTrace lower-cased doesn't contain the parameter as substring, errorStackTrace: the error stack trace",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -13037,7 +12854,7 @@
             },
             {
               "name": "errorStackTrace_l_starts_with",
-              "description": "errorStackTrace lowercased starts with the parameter value, errorStackTrace: the error stack trace",
+              "description": "errorStackTrace lower-cased starts with the parameter value, errorStackTrace: the error stack trace",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -13047,7 +12864,7 @@
             },
             {
               "name": "errorStackTrace_l_not_starts_with",
-              "description": "errorStackTrace lowercased doesn't start with the parameter value, errorStackTrace: the error stack trace",
+              "description": "errorStackTrace lower-cased doesn't start with the parameter value, errorStackTrace: the error stack trace",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -13057,7 +12874,7 @@
             },
             {
               "name": "errorStackTrace_l_ends_with",
-              "description": "errorStackTrace lowercased ends with the parameter value, errorStackTrace: the error stack trace",
+              "description": "errorStackTrace lower-cased ends with the parameter value, errorStackTrace: the error stack trace",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -13067,7 +12884,7 @@
             },
             {
               "name": "errorStackTrace_l_not_ends_with",
-              "description": "errorStackTrace lowercased doesn't end with the parameter value, errorStackTrace: the error stack trace",
+              "description": "errorStackTrace lower-cased doesn't end with the parameter value, errorStackTrace: the error stack trace",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -13078,6 +12895,209 @@
           ],
           "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "KlusterKiteNodeApi_MigrationLogRecord_Sort",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "id_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "migrationId_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "migrationId_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "configurationId_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "configurationId_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "migratorTemplateCode_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "migratorTemplateCode_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "migratorTemplateName_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "migratorTemplateName_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "migratorTypeName_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "migratorTypeName_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "migratorName_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "migratorName_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "resourceCode_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "resourceCode_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "resourceName_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "resourceName_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "started_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "started_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "finished_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "finished_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sourcePoint_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sourcePoint_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "destinationPoint_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "destinationPoint_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "message_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "message_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "errorStackTrace_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "errorStackTrace_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -13235,7 +13255,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -13267,6 +13287,16 @@
               "description": "the list of migration states",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -13277,11 +13307,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_MigratorTemplateMigrationState_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -13301,21 +13331,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_MigratorTemplateMigrationState_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -13334,6 +13354,16 @@
               "description": "the list of resources that can be migrated on current stage",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -13344,11 +13374,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_ResourceMigrationState_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -13368,21 +13398,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_ResourceMigrationState_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -13398,7 +13418,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -13443,7 +13463,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -13484,7 +13504,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -13564,6 +13584,16 @@
               "description": "the list of states of migrators",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -13574,11 +13604,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_MigratorMigrationState_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -13598,21 +13628,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_MigratorMigrationState_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -13628,7 +13648,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -13702,7 +13722,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -13743,7 +13763,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -13811,6 +13831,16 @@
               "description": "the list of resources states",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -13821,11 +13851,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_ResourceMigrationState_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -13845,21 +13875,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_ResourceMigrationState_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -13911,7 +13931,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -13956,7 +13976,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -13997,7 +14017,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -14158,7 +14178,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -14238,149 +14258,6 @@
             {
               "name": "Obsolete",
               "description": "The resource is no more supported in the target configuration",
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "ENUM",
-          "name": "KlusterKiteNodeApi_ResourceMigrationState_Sort",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "sourcePoint_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "sourcePoint_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "destinationPoint_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "destinationPoint_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "migrationToSourceExecutor_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "migrationToSourceExecutor_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "migrationToDestinationExecutor_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "migrationToDestinationExecutor_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "key_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "key_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "code_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "code_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "currentPoint_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "currentPoint_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "position_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "position_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "templateCode_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "templateCode_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "migratorTypeName_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "migratorTypeName_desc",
-              "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -14515,7 +14392,7 @@
             },
             {
               "name": "sourcePoint_l",
-              "description": "sourcePoint lowercased equals the parameter, sourcePoint: the migration source position for this resource type",
+              "description": "sourcePoint lower-cased equals the parameter, sourcePoint: the migration source position for this resource type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14525,7 +14402,7 @@
             },
             {
               "name": "sourcePoint_l_not",
-              "description": "sourcePoint lowercased doesn't equal the parameter, sourcePoint: the migration source position for this resource type",
+              "description": "sourcePoint lower-cased doesn't equal the parameter, sourcePoint: the migration source position for this resource type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14535,7 +14412,7 @@
             },
             {
               "name": "sourcePoint_l_in",
-              "description": "sourcePoint lowercased is a substring of the parameter, sourcePoint: the migration source position for this resource type",
+              "description": "sourcePoint lower-cased is a substring of the parameter, sourcePoint: the migration source position for this resource type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14545,7 +14422,7 @@
             },
             {
               "name": "sourcePoint_l_not_in",
-              "description": "sourcePoint lowercased is not a substring of the parameter, sourcePoint: the migration source position for this resource type",
+              "description": "sourcePoint lower-cased is not a substring of the parameter, sourcePoint: the migration source position for this resource type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14555,7 +14432,7 @@
             },
             {
               "name": "sourcePoint_l_contains",
-              "description": "sourcePoint lowercased contains the parameter as substring, sourcePoint: the migration source position for this resource type",
+              "description": "sourcePoint lower-cased contains the parameter as substring, sourcePoint: the migration source position for this resource type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14565,7 +14442,7 @@
             },
             {
               "name": "sourcePoint_l_not_contains",
-              "description": "sourcePoint lowercased doesn't contain the parameter as substring, sourcePoint: the migration source position for this resource type",
+              "description": "sourcePoint lower-cased doesn't contain the parameter as substring, sourcePoint: the migration source position for this resource type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14575,7 +14452,7 @@
             },
             {
               "name": "sourcePoint_l_starts_with",
-              "description": "sourcePoint lowercased starts with the parameter value, sourcePoint: the migration source position for this resource type",
+              "description": "sourcePoint lower-cased starts with the parameter value, sourcePoint: the migration source position for this resource type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14585,7 +14462,7 @@
             },
             {
               "name": "sourcePoint_l_not_starts_with",
-              "description": "sourcePoint lowercased doesn't start with the parameter value, sourcePoint: the migration source position for this resource type",
+              "description": "sourcePoint lower-cased doesn't start with the parameter value, sourcePoint: the migration source position for this resource type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14595,7 +14472,7 @@
             },
             {
               "name": "sourcePoint_l_ends_with",
-              "description": "sourcePoint lowercased ends with the parameter value, sourcePoint: the migration source position for this resource type",
+              "description": "sourcePoint lower-cased ends with the parameter value, sourcePoint: the migration source position for this resource type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14605,7 +14482,7 @@
             },
             {
               "name": "sourcePoint_l_not_ends_with",
-              "description": "sourcePoint lowercased doesn't end with the parameter value, sourcePoint: the migration source position for this resource type",
+              "description": "sourcePoint lower-cased doesn't end with the parameter value, sourcePoint: the migration source position for this resource type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14715,7 +14592,7 @@
             },
             {
               "name": "destinationPoint_l",
-              "description": "destinationPoint lowercased equals the parameter, destinationPoint: the migration destination position for this resource type",
+              "description": "destinationPoint lower-cased equals the parameter, destinationPoint: the migration destination position for this resource type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14725,7 +14602,7 @@
             },
             {
               "name": "destinationPoint_l_not",
-              "description": "destinationPoint lowercased doesn't equal the parameter, destinationPoint: the migration destination position for this resource type",
+              "description": "destinationPoint lower-cased doesn't equal the parameter, destinationPoint: the migration destination position for this resource type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14735,7 +14612,7 @@
             },
             {
               "name": "destinationPoint_l_in",
-              "description": "destinationPoint lowercased is a substring of the parameter, destinationPoint: the migration destination position for this resource type",
+              "description": "destinationPoint lower-cased is a substring of the parameter, destinationPoint: the migration destination position for this resource type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14745,7 +14622,7 @@
             },
             {
               "name": "destinationPoint_l_not_in",
-              "description": "destinationPoint lowercased is not a substring of the parameter, destinationPoint: the migration destination position for this resource type",
+              "description": "destinationPoint lower-cased is not a substring of the parameter, destinationPoint: the migration destination position for this resource type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14755,7 +14632,7 @@
             },
             {
               "name": "destinationPoint_l_contains",
-              "description": "destinationPoint lowercased contains the parameter as substring, destinationPoint: the migration destination position for this resource type",
+              "description": "destinationPoint lower-cased contains the parameter as substring, destinationPoint: the migration destination position for this resource type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14765,7 +14642,7 @@
             },
             {
               "name": "destinationPoint_l_not_contains",
-              "description": "destinationPoint lowercased doesn't contain the parameter as substring, destinationPoint: the migration destination position for this resource type",
+              "description": "destinationPoint lower-cased doesn't contain the parameter as substring, destinationPoint: the migration destination position for this resource type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14775,7 +14652,7 @@
             },
             {
               "name": "destinationPoint_l_starts_with",
-              "description": "destinationPoint lowercased starts with the parameter value, destinationPoint: the migration destination position for this resource type",
+              "description": "destinationPoint lower-cased starts with the parameter value, destinationPoint: the migration destination position for this resource type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14785,7 +14662,7 @@
             },
             {
               "name": "destinationPoint_l_not_starts_with",
-              "description": "destinationPoint lowercased doesn't start with the parameter value, destinationPoint: the migration destination position for this resource type",
+              "description": "destinationPoint lower-cased doesn't start with the parameter value, destinationPoint: the migration destination position for this resource type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14795,7 +14672,7 @@
             },
             {
               "name": "destinationPoint_l_ends_with",
-              "description": "destinationPoint lowercased ends with the parameter value, destinationPoint: the migration destination position for this resource type",
+              "description": "destinationPoint lower-cased ends with the parameter value, destinationPoint: the migration destination position for this resource type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14805,7 +14682,7 @@
             },
             {
               "name": "destinationPoint_l_not_ends_with",
-              "description": "destinationPoint lowercased doesn't end with the parameter value, destinationPoint: the migration destination position for this resource type",
+              "description": "destinationPoint lower-cased doesn't end with the parameter value, destinationPoint: the migration destination position for this resource type",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14955,7 +14832,7 @@
             },
             {
               "name": "key_l",
-              "description": "key lowercased equals the parameter, key: the resource unique key",
+              "description": "key lower-cased equals the parameter, key: the resource unique key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14965,7 +14842,7 @@
             },
             {
               "name": "key_l_not",
-              "description": "key lowercased doesn't equal the parameter, key: the resource unique key",
+              "description": "key lower-cased doesn't equal the parameter, key: the resource unique key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14975,7 +14852,7 @@
             },
             {
               "name": "key_l_in",
-              "description": "key lowercased is a substring of the parameter, key: the resource unique key",
+              "description": "key lower-cased is a substring of the parameter, key: the resource unique key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14985,7 +14862,7 @@
             },
             {
               "name": "key_l_not_in",
-              "description": "key lowercased is not a substring of the parameter, key: the resource unique key",
+              "description": "key lower-cased is not a substring of the parameter, key: the resource unique key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -14995,7 +14872,7 @@
             },
             {
               "name": "key_l_contains",
-              "description": "key lowercased contains the parameter as substring, key: the resource unique key",
+              "description": "key lower-cased contains the parameter as substring, key: the resource unique key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15005,7 +14882,7 @@
             },
             {
               "name": "key_l_not_contains",
-              "description": "key lowercased doesn't contain the parameter as substring, key: the resource unique key",
+              "description": "key lower-cased doesn't contain the parameter as substring, key: the resource unique key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15015,7 +14892,7 @@
             },
             {
               "name": "key_l_starts_with",
-              "description": "key lowercased starts with the parameter value, key: the resource unique key",
+              "description": "key lower-cased starts with the parameter value, key: the resource unique key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15025,7 +14902,7 @@
             },
             {
               "name": "key_l_not_starts_with",
-              "description": "key lowercased doesn't start with the parameter value, key: the resource unique key",
+              "description": "key lower-cased doesn't start with the parameter value, key: the resource unique key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15035,7 +14912,7 @@
             },
             {
               "name": "key_l_ends_with",
-              "description": "key lowercased ends with the parameter value, key: the resource unique key",
+              "description": "key lower-cased ends with the parameter value, key: the resource unique key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15045,7 +14922,7 @@
             },
             {
               "name": "key_l_not_ends_with",
-              "description": "key lowercased doesn't end with the parameter value, key: the resource unique key",
+              "description": "key lower-cased doesn't end with the parameter value, key: the resource unique key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15155,7 +15032,7 @@
             },
             {
               "name": "name_l",
-              "description": "name lowercased equals the parameter, name: the human readable resource name",
+              "description": "name lower-cased equals the parameter, name: the human readable resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15165,7 +15042,7 @@
             },
             {
               "name": "name_l_not",
-              "description": "name lowercased doesn't equal the parameter, name: the human readable resource name",
+              "description": "name lower-cased doesn't equal the parameter, name: the human readable resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15175,7 +15052,7 @@
             },
             {
               "name": "name_l_in",
-              "description": "name lowercased is a substring of the parameter, name: the human readable resource name",
+              "description": "name lower-cased is a substring of the parameter, name: the human readable resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15185,7 +15062,7 @@
             },
             {
               "name": "name_l_not_in",
-              "description": "name lowercased is not a substring of the parameter, name: the human readable resource name",
+              "description": "name lower-cased is not a substring of the parameter, name: the human readable resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15195,7 +15072,7 @@
             },
             {
               "name": "name_l_contains",
-              "description": "name lowercased contains the parameter as substring, name: the human readable resource name",
+              "description": "name lower-cased contains the parameter as substring, name: the human readable resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15205,7 +15082,7 @@
             },
             {
               "name": "name_l_not_contains",
-              "description": "name lowercased doesn't contain the parameter as substring, name: the human readable resource name",
+              "description": "name lower-cased doesn't contain the parameter as substring, name: the human readable resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15215,7 +15092,7 @@
             },
             {
               "name": "name_l_starts_with",
-              "description": "name lowercased starts with the parameter value, name: the human readable resource name",
+              "description": "name lower-cased starts with the parameter value, name: the human readable resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15225,7 +15102,7 @@
             },
             {
               "name": "name_l_not_starts_with",
-              "description": "name lowercased doesn't start with the parameter value, name: the human readable resource name",
+              "description": "name lower-cased doesn't start with the parameter value, name: the human readable resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15235,7 +15112,7 @@
             },
             {
               "name": "name_l_ends_with",
-              "description": "name lowercased ends with the parameter value, name: the human readable resource name",
+              "description": "name lower-cased ends with the parameter value, name: the human readable resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15245,7 +15122,7 @@
             },
             {
               "name": "name_l_not_ends_with",
-              "description": "name lowercased doesn't end with the parameter value, name: the human readable resource name",
+              "description": "name lower-cased doesn't end with the parameter value, name: the human readable resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15355,7 +15232,7 @@
             },
             {
               "name": "code_l",
-              "description": "code lowercased equals the parameter, code: the resource identification",
+              "description": "code lower-cased equals the parameter, code: the resource identification",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15365,7 +15242,7 @@
             },
             {
               "name": "code_l_not",
-              "description": "code lowercased doesn't equal the parameter, code: the resource identification",
+              "description": "code lower-cased doesn't equal the parameter, code: the resource identification",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15375,7 +15252,7 @@
             },
             {
               "name": "code_l_in",
-              "description": "code lowercased is a substring of the parameter, code: the resource identification",
+              "description": "code lower-cased is a substring of the parameter, code: the resource identification",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15385,7 +15262,7 @@
             },
             {
               "name": "code_l_not_in",
-              "description": "code lowercased is not a substring of the parameter, code: the resource identification",
+              "description": "code lower-cased is not a substring of the parameter, code: the resource identification",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15395,7 +15272,7 @@
             },
             {
               "name": "code_l_contains",
-              "description": "code lowercased contains the parameter as substring, code: the resource identification",
+              "description": "code lower-cased contains the parameter as substring, code: the resource identification",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15405,7 +15282,7 @@
             },
             {
               "name": "code_l_not_contains",
-              "description": "code lowercased doesn't contain the parameter as substring, code: the resource identification",
+              "description": "code lower-cased doesn't contain the parameter as substring, code: the resource identification",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15415,7 +15292,7 @@
             },
             {
               "name": "code_l_starts_with",
-              "description": "code lowercased starts with the parameter value, code: the resource identification",
+              "description": "code lower-cased starts with the parameter value, code: the resource identification",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15425,7 +15302,7 @@
             },
             {
               "name": "code_l_not_starts_with",
-              "description": "code lowercased doesn't start with the parameter value, code: the resource identification",
+              "description": "code lower-cased doesn't start with the parameter value, code: the resource identification",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15435,7 +15312,7 @@
             },
             {
               "name": "code_l_ends_with",
-              "description": "code lowercased ends with the parameter value, code: the resource identification",
+              "description": "code lower-cased ends with the parameter value, code: the resource identification",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15445,7 +15322,7 @@
             },
             {
               "name": "code_l_not_ends_with",
-              "description": "code lowercased doesn't end with the parameter value, code: the resource identification",
+              "description": "code lower-cased doesn't end with the parameter value, code: the resource identification",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15555,7 +15432,7 @@
             },
             {
               "name": "currentPoint_l",
-              "description": "currentPoint lowercased equals the parameter, currentPoint: the current migration point of the resource",
+              "description": "currentPoint lower-cased equals the parameter, currentPoint: the current migration point of the resource",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15565,7 +15442,7 @@
             },
             {
               "name": "currentPoint_l_not",
-              "description": "currentPoint lowercased doesn't equal the parameter, currentPoint: the current migration point of the resource",
+              "description": "currentPoint lower-cased doesn't equal the parameter, currentPoint: the current migration point of the resource",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15575,7 +15452,7 @@
             },
             {
               "name": "currentPoint_l_in",
-              "description": "currentPoint lowercased is a substring of the parameter, currentPoint: the current migration point of the resource",
+              "description": "currentPoint lower-cased is a substring of the parameter, currentPoint: the current migration point of the resource",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15585,7 +15462,7 @@
             },
             {
               "name": "currentPoint_l_not_in",
-              "description": "currentPoint lowercased is not a substring of the parameter, currentPoint: the current migration point of the resource",
+              "description": "currentPoint lower-cased is not a substring of the parameter, currentPoint: the current migration point of the resource",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15595,7 +15472,7 @@
             },
             {
               "name": "currentPoint_l_contains",
-              "description": "currentPoint lowercased contains the parameter as substring, currentPoint: the current migration point of the resource",
+              "description": "currentPoint lower-cased contains the parameter as substring, currentPoint: the current migration point of the resource",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15605,7 +15482,7 @@
             },
             {
               "name": "currentPoint_l_not_contains",
-              "description": "currentPoint lowercased doesn't contain the parameter as substring, currentPoint: the current migration point of the resource",
+              "description": "currentPoint lower-cased doesn't contain the parameter as substring, currentPoint: the current migration point of the resource",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15615,7 +15492,7 @@
             },
             {
               "name": "currentPoint_l_starts_with",
-              "description": "currentPoint lowercased starts with the parameter value, currentPoint: the current migration point of the resource",
+              "description": "currentPoint lower-cased starts with the parameter value, currentPoint: the current migration point of the resource",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15625,7 +15502,7 @@
             },
             {
               "name": "currentPoint_l_not_starts_with",
-              "description": "currentPoint lowercased doesn't start with the parameter value, currentPoint: the current migration point of the resource",
+              "description": "currentPoint lower-cased doesn't start with the parameter value, currentPoint: the current migration point of the resource",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15635,7 +15512,7 @@
             },
             {
               "name": "currentPoint_l_ends_with",
-              "description": "currentPoint lowercased ends with the parameter value, currentPoint: the current migration point of the resource",
+              "description": "currentPoint lower-cased ends with the parameter value, currentPoint: the current migration point of the resource",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15645,7 +15522,7 @@
             },
             {
               "name": "currentPoint_l_not_ends_with",
-              "description": "currentPoint lowercased doesn't end with the parameter value, currentPoint: the current migration point of the resource",
+              "description": "currentPoint lower-cased doesn't end with the parameter value, currentPoint: the current migration point of the resource",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15775,7 +15652,7 @@
             },
             {
               "name": "templateCode_l",
-              "description": "templateCode lowercased equals the parameter, templateCode: The code of migrator template",
+              "description": "templateCode lower-cased equals the parameter, templateCode: The code of migrator template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15785,7 +15662,7 @@
             },
             {
               "name": "templateCode_l_not",
-              "description": "templateCode lowercased doesn't equal the parameter, templateCode: The code of migrator template",
+              "description": "templateCode lower-cased doesn't equal the parameter, templateCode: The code of migrator template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15795,7 +15672,7 @@
             },
             {
               "name": "templateCode_l_in",
-              "description": "templateCode lowercased is a substring of the parameter, templateCode: The code of migrator template",
+              "description": "templateCode lower-cased is a substring of the parameter, templateCode: The code of migrator template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15805,7 +15682,7 @@
             },
             {
               "name": "templateCode_l_not_in",
-              "description": "templateCode lowercased is not a substring of the parameter, templateCode: The code of migrator template",
+              "description": "templateCode lower-cased is not a substring of the parameter, templateCode: The code of migrator template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15815,7 +15692,7 @@
             },
             {
               "name": "templateCode_l_contains",
-              "description": "templateCode lowercased contains the parameter as substring, templateCode: The code of migrator template",
+              "description": "templateCode lower-cased contains the parameter as substring, templateCode: The code of migrator template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15825,7 +15702,7 @@
             },
             {
               "name": "templateCode_l_not_contains",
-              "description": "templateCode lowercased doesn't contain the parameter as substring, templateCode: The code of migrator template",
+              "description": "templateCode lower-cased doesn't contain the parameter as substring, templateCode: The code of migrator template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15835,7 +15712,7 @@
             },
             {
               "name": "templateCode_l_starts_with",
-              "description": "templateCode lowercased starts with the parameter value, templateCode: The code of migrator template",
+              "description": "templateCode lower-cased starts with the parameter value, templateCode: The code of migrator template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15845,7 +15722,7 @@
             },
             {
               "name": "templateCode_l_not_starts_with",
-              "description": "templateCode lowercased doesn't start with the parameter value, templateCode: The code of migrator template",
+              "description": "templateCode lower-cased doesn't start with the parameter value, templateCode: The code of migrator template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15855,7 +15732,7 @@
             },
             {
               "name": "templateCode_l_ends_with",
-              "description": "templateCode lowercased ends with the parameter value, templateCode: The code of migrator template",
+              "description": "templateCode lower-cased ends with the parameter value, templateCode: The code of migrator template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15865,7 +15742,7 @@
             },
             {
               "name": "templateCode_l_not_ends_with",
-              "description": "templateCode lowercased doesn't end with the parameter value, templateCode: The code of migrator template",
+              "description": "templateCode lower-cased doesn't end with the parameter value, templateCode: The code of migrator template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15975,7 +15852,7 @@
             },
             {
               "name": "migratorTypeName_l",
-              "description": "migratorTypeName lowercased equals the parameter, migratorTypeName: The type name of the migrator",
+              "description": "migratorTypeName lower-cased equals the parameter, migratorTypeName: The type name of the migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15985,7 +15862,7 @@
             },
             {
               "name": "migratorTypeName_l_not",
-              "description": "migratorTypeName lowercased doesn't equal the parameter, migratorTypeName: The type name of the migrator",
+              "description": "migratorTypeName lower-cased doesn't equal the parameter, migratorTypeName: The type name of the migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -15995,7 +15872,7 @@
             },
             {
               "name": "migratorTypeName_l_in",
-              "description": "migratorTypeName lowercased is a substring of the parameter, migratorTypeName: The type name of the migrator",
+              "description": "migratorTypeName lower-cased is a substring of the parameter, migratorTypeName: The type name of the migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16005,7 +15882,7 @@
             },
             {
               "name": "migratorTypeName_l_not_in",
-              "description": "migratorTypeName lowercased is not a substring of the parameter, migratorTypeName: The type name of the migrator",
+              "description": "migratorTypeName lower-cased is not a substring of the parameter, migratorTypeName: The type name of the migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16015,7 +15892,7 @@
             },
             {
               "name": "migratorTypeName_l_contains",
-              "description": "migratorTypeName lowercased contains the parameter as substring, migratorTypeName: The type name of the migrator",
+              "description": "migratorTypeName lower-cased contains the parameter as substring, migratorTypeName: The type name of the migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16025,7 +15902,7 @@
             },
             {
               "name": "migratorTypeName_l_not_contains",
-              "description": "migratorTypeName lowercased doesn't contain the parameter as substring, migratorTypeName: The type name of the migrator",
+              "description": "migratorTypeName lower-cased doesn't contain the parameter as substring, migratorTypeName: The type name of the migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16035,7 +15912,7 @@
             },
             {
               "name": "migratorTypeName_l_starts_with",
-              "description": "migratorTypeName lowercased starts with the parameter value, migratorTypeName: The type name of the migrator",
+              "description": "migratorTypeName lower-cased starts with the parameter value, migratorTypeName: The type name of the migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16045,7 +15922,7 @@
             },
             {
               "name": "migratorTypeName_l_not_starts_with",
-              "description": "migratorTypeName lowercased doesn't start with the parameter value, migratorTypeName: The type name of the migrator",
+              "description": "migratorTypeName lower-cased doesn't start with the parameter value, migratorTypeName: The type name of the migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16055,7 +15932,7 @@
             },
             {
               "name": "migratorTypeName_l_ends_with",
-              "description": "migratorTypeName lowercased ends with the parameter value, migratorTypeName: The type name of the migrator",
+              "description": "migratorTypeName lower-cased ends with the parameter value, migratorTypeName: The type name of the migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16065,7 +15942,7 @@
             },
             {
               "name": "migratorTypeName_l_not_ends_with",
-              "description": "migratorTypeName lowercased doesn't end with the parameter value, migratorTypeName: The type name of the migrator",
+              "description": "migratorTypeName lower-cased doesn't end with the parameter value, migratorTypeName: The type name of the migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16076,6 +15953,149 @@
           ],
           "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "KlusterKiteNodeApi_ResourceMigrationState_Sort",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "sourcePoint_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sourcePoint_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "destinationPoint_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "destinationPoint_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "migrationToSourceExecutor_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "migrationToSourceExecutor_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "migrationToDestinationExecutor_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "migrationToDestinationExecutor_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "key_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "key_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "code_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "code_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currentPoint_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currentPoint_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "position_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "position_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "templateCode_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "templateCode_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "migratorTypeName_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "migratorTypeName_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -16114,6 +16134,16 @@
           "possibleTypes": null
         },
         {
+          "kind": "SCALAR",
+          "name": "Decimal",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "ENUM",
           "name": "KlusterKiteNodeApi_EnResourceType",
           "description": null,
@@ -16130,89 +16160,6 @@
             {
               "name": "ResourceDependsOnCode",
               "description": "The resource depends on code (so code should be updated prior to resource",
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "ENUM",
-          "name": "KlusterKiteNodeApi_MigratorMigrationState_Sort",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "typeName_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "typeName_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "position_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "position_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "direction_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "direction_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "priority_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "priority_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "dependencyType_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "dependencyType_desc",
-              "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -16347,7 +16294,7 @@
             },
             {
               "name": "typeName_l",
-              "description": "typeName lowercased equals the parameter, typeName: the migrator type name",
+              "description": "typeName lower-cased equals the parameter, typeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16357,7 +16304,7 @@
             },
             {
               "name": "typeName_l_not",
-              "description": "typeName lowercased doesn't equal the parameter, typeName: the migrator type name",
+              "description": "typeName lower-cased doesn't equal the parameter, typeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16367,7 +16314,7 @@
             },
             {
               "name": "typeName_l_in",
-              "description": "typeName lowercased is a substring of the parameter, typeName: the migrator type name",
+              "description": "typeName lower-cased is a substring of the parameter, typeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16377,7 +16324,7 @@
             },
             {
               "name": "typeName_l_not_in",
-              "description": "typeName lowercased is not a substring of the parameter, typeName: the migrator type name",
+              "description": "typeName lower-cased is not a substring of the parameter, typeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16387,7 +16334,7 @@
             },
             {
               "name": "typeName_l_contains",
-              "description": "typeName lowercased contains the parameter as substring, typeName: the migrator type name",
+              "description": "typeName lower-cased contains the parameter as substring, typeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16397,7 +16344,7 @@
             },
             {
               "name": "typeName_l_not_contains",
-              "description": "typeName lowercased doesn't contain the parameter as substring, typeName: the migrator type name",
+              "description": "typeName lower-cased doesn't contain the parameter as substring, typeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16407,7 +16354,7 @@
             },
             {
               "name": "typeName_l_starts_with",
-              "description": "typeName lowercased starts with the parameter value, typeName: the migrator type name",
+              "description": "typeName lower-cased starts with the parameter value, typeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16417,7 +16364,7 @@
             },
             {
               "name": "typeName_l_not_starts_with",
-              "description": "typeName lowercased doesn't start with the parameter value, typeName: the migrator type name",
+              "description": "typeName lower-cased doesn't start with the parameter value, typeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16427,7 +16374,7 @@
             },
             {
               "name": "typeName_l_ends_with",
-              "description": "typeName lowercased ends with the parameter value, typeName: the migrator type name",
+              "description": "typeName lower-cased ends with the parameter value, typeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16437,7 +16384,7 @@
             },
             {
               "name": "typeName_l_not_ends_with",
-              "description": "typeName lowercased doesn't end with the parameter value, typeName: the migrator type name",
+              "description": "typeName lower-cased doesn't end with the parameter value, typeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16547,7 +16494,7 @@
             },
             {
               "name": "name_l",
-              "description": "name lowercased equals the parameter, name: the migrator name",
+              "description": "name lower-cased equals the parameter, name: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16557,7 +16504,7 @@
             },
             {
               "name": "name_l_not",
-              "description": "name lowercased doesn't equal the parameter, name: the migrator name",
+              "description": "name lower-cased doesn't equal the parameter, name: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16567,7 +16514,7 @@
             },
             {
               "name": "name_l_in",
-              "description": "name lowercased is a substring of the parameter, name: the migrator name",
+              "description": "name lower-cased is a substring of the parameter, name: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16577,7 +16524,7 @@
             },
             {
               "name": "name_l_not_in",
-              "description": "name lowercased is not a substring of the parameter, name: the migrator name",
+              "description": "name lower-cased is not a substring of the parameter, name: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16587,7 +16534,7 @@
             },
             {
               "name": "name_l_contains",
-              "description": "name lowercased contains the parameter as substring, name: the migrator name",
+              "description": "name lower-cased contains the parameter as substring, name: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16597,7 +16544,7 @@
             },
             {
               "name": "name_l_not_contains",
-              "description": "name lowercased doesn't contain the parameter as substring, name: the migrator name",
+              "description": "name lower-cased doesn't contain the parameter as substring, name: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16607,7 +16554,7 @@
             },
             {
               "name": "name_l_starts_with",
-              "description": "name lowercased starts with the parameter value, name: the migrator name",
+              "description": "name lower-cased starts with the parameter value, name: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16617,7 +16564,7 @@
             },
             {
               "name": "name_l_not_starts_with",
-              "description": "name lowercased doesn't start with the parameter value, name: the migrator name",
+              "description": "name lower-cased doesn't start with the parameter value, name: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16627,7 +16574,7 @@
             },
             {
               "name": "name_l_ends_with",
-              "description": "name lowercased ends with the parameter value, name: the migrator name",
+              "description": "name lower-cased ends with the parameter value, name: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16637,7 +16584,7 @@
             },
             {
               "name": "name_l_not_ends_with",
-              "description": "name lowercased doesn't end with the parameter value, name: the migrator name",
+              "description": "name lower-cased doesn't end with the parameter value, name: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16772,20 +16719,32 @@
         },
         {
           "kind": "ENUM",
-          "name": "KlusterKiteNodeApi_MigratorTemplateMigrationState_Sort",
+          "name": "KlusterKiteNodeApi_MigratorMigrationState_Sort",
           "description": null,
           "fields": null,
           "inputFields": null,
           "interfaces": null,
           "enumValues": [
             {
-              "name": "code_asc",
+              "name": "typeName_asc",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "code_desc",
+              "name": "typeName_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_desc",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -16798,6 +16757,42 @@
             },
             {
               "name": "position_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "direction_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "direction_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "priority_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "priority_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dependencyType_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dependencyType_desc",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -16933,7 +16928,7 @@
             },
             {
               "name": "code_l",
-              "description": "code lowercased equals the parameter, code: the template code",
+              "description": "code lower-cased equals the parameter, code: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16943,7 +16938,7 @@
             },
             {
               "name": "code_l_not",
-              "description": "code lowercased doesn't equal the parameter, code: the template code",
+              "description": "code lower-cased doesn't equal the parameter, code: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16953,7 +16948,7 @@
             },
             {
               "name": "code_l_in",
-              "description": "code lowercased is a substring of the parameter, code: the template code",
+              "description": "code lower-cased is a substring of the parameter, code: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16963,7 +16958,7 @@
             },
             {
               "name": "code_l_not_in",
-              "description": "code lowercased is not a substring of the parameter, code: the template code",
+              "description": "code lower-cased is not a substring of the parameter, code: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16973,7 +16968,7 @@
             },
             {
               "name": "code_l_contains",
-              "description": "code lowercased contains the parameter as substring, code: the template code",
+              "description": "code lower-cased contains the parameter as substring, code: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16983,7 +16978,7 @@
             },
             {
               "name": "code_l_not_contains",
-              "description": "code lowercased doesn't contain the parameter as substring, code: the template code",
+              "description": "code lower-cased doesn't contain the parameter as substring, code: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -16993,7 +16988,7 @@
             },
             {
               "name": "code_l_starts_with",
-              "description": "code lowercased starts with the parameter value, code: the template code",
+              "description": "code lower-cased starts with the parameter value, code: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -17003,7 +16998,7 @@
             },
             {
               "name": "code_l_not_starts_with",
-              "description": "code lowercased doesn't start with the parameter value, code: the template code",
+              "description": "code lower-cased doesn't start with the parameter value, code: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -17013,7 +17008,7 @@
             },
             {
               "name": "code_l_ends_with",
-              "description": "code lowercased ends with the parameter value, code: the template code",
+              "description": "code lower-cased ends with the parameter value, code: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -17023,7 +17018,7 @@
             },
             {
               "name": "code_l_not_ends_with",
-              "description": "code lowercased doesn't end with the parameter value, code: the template code",
+              "description": "code lower-cased doesn't end with the parameter value, code: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -17057,6 +17052,41 @@
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "KlusterKiteNodeApi_MigratorTemplateMigrationState_Sort",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "code_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "code_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "position_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "position_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
           "kind": "INTERFACE",
           "name": "IKlusterKiteNodeApi_MigrationActorConfigurationState",
           "description": "The MigrationActor state with no active migration",
@@ -17078,6 +17108,16 @@
               "description": "the list of template states",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -17088,11 +17128,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_MigratorTemplateConfigurationState_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -17112,21 +17152,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_MigratorTemplateConfigurationState_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -17145,6 +17175,16 @@
               "description": "the list of resources that can be recovered",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -17155,11 +17195,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_ResourceConfigurationState_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -17179,21 +17219,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_ResourceConfigurationState_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -17209,7 +17239,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -17254,7 +17284,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -17295,7 +17325,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -17351,6 +17381,16 @@
               "description": "the migrator states",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -17361,11 +17401,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_MigratorConfigurationState_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -17385,21 +17425,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_MigratorConfigurationState_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -17415,7 +17445,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -17460,7 +17490,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -17501,7 +17531,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -17585,6 +17615,16 @@
               "description": "the state of defined resources",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -17595,11 +17635,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_ResourceConfigurationState_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -17619,21 +17659,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_ResourceConfigurationState_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -17673,7 +17703,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -17718,7 +17748,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -17759,7 +17789,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -17872,7 +17902,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -17881,101 +17911,6 @@
               "ofType": null
             }
           ]
-        },
-        {
-          "kind": "ENUM",
-          "name": "KlusterKiteNodeApi_ResourceConfigurationState_Sort",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "key_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "key_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "code_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "code_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "currentPoint_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "currentPoint_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "position_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "position_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "templateCode_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "templateCode_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "migratorTypeName_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "migratorTypeName_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
         },
         {
           "kind": "INPUT_OBJECT",
@@ -18105,7 +18040,7 @@
             },
             {
               "name": "key_l",
-              "description": "key lowercased equals the parameter, key: the resource unique key",
+              "description": "key lower-cased equals the parameter, key: the resource unique key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18115,7 +18050,7 @@
             },
             {
               "name": "key_l_not",
-              "description": "key lowercased doesn't equal the parameter, key: the resource unique key",
+              "description": "key lower-cased doesn't equal the parameter, key: the resource unique key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18125,7 +18060,7 @@
             },
             {
               "name": "key_l_in",
-              "description": "key lowercased is a substring of the parameter, key: the resource unique key",
+              "description": "key lower-cased is a substring of the parameter, key: the resource unique key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18135,7 +18070,7 @@
             },
             {
               "name": "key_l_not_in",
-              "description": "key lowercased is not a substring of the parameter, key: the resource unique key",
+              "description": "key lower-cased is not a substring of the parameter, key: the resource unique key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18145,7 +18080,7 @@
             },
             {
               "name": "key_l_contains",
-              "description": "key lowercased contains the parameter as substring, key: the resource unique key",
+              "description": "key lower-cased contains the parameter as substring, key: the resource unique key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18155,7 +18090,7 @@
             },
             {
               "name": "key_l_not_contains",
-              "description": "key lowercased doesn't contain the parameter as substring, key: the resource unique key",
+              "description": "key lower-cased doesn't contain the parameter as substring, key: the resource unique key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18165,7 +18100,7 @@
             },
             {
               "name": "key_l_starts_with",
-              "description": "key lowercased starts with the parameter value, key: the resource unique key",
+              "description": "key lower-cased starts with the parameter value, key: the resource unique key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18175,7 +18110,7 @@
             },
             {
               "name": "key_l_not_starts_with",
-              "description": "key lowercased doesn't start with the parameter value, key: the resource unique key",
+              "description": "key lower-cased doesn't start with the parameter value, key: the resource unique key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18185,7 +18120,7 @@
             },
             {
               "name": "key_l_ends_with",
-              "description": "key lowercased ends with the parameter value, key: the resource unique key",
+              "description": "key lower-cased ends with the parameter value, key: the resource unique key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18195,7 +18130,7 @@
             },
             {
               "name": "key_l_not_ends_with",
-              "description": "key lowercased doesn't end with the parameter value, key: the resource unique key",
+              "description": "key lower-cased doesn't end with the parameter value, key: the resource unique key",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18305,7 +18240,7 @@
             },
             {
               "name": "name_l",
-              "description": "name lowercased equals the parameter, name: the human readable resource name",
+              "description": "name lower-cased equals the parameter, name: the human readable resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18315,7 +18250,7 @@
             },
             {
               "name": "name_l_not",
-              "description": "name lowercased doesn't equal the parameter, name: the human readable resource name",
+              "description": "name lower-cased doesn't equal the parameter, name: the human readable resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18325,7 +18260,7 @@
             },
             {
               "name": "name_l_in",
-              "description": "name lowercased is a substring of the parameter, name: the human readable resource name",
+              "description": "name lower-cased is a substring of the parameter, name: the human readable resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18335,7 +18270,7 @@
             },
             {
               "name": "name_l_not_in",
-              "description": "name lowercased is not a substring of the parameter, name: the human readable resource name",
+              "description": "name lower-cased is not a substring of the parameter, name: the human readable resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18345,7 +18280,7 @@
             },
             {
               "name": "name_l_contains",
-              "description": "name lowercased contains the parameter as substring, name: the human readable resource name",
+              "description": "name lower-cased contains the parameter as substring, name: the human readable resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18355,7 +18290,7 @@
             },
             {
               "name": "name_l_not_contains",
-              "description": "name lowercased doesn't contain the parameter as substring, name: the human readable resource name",
+              "description": "name lower-cased doesn't contain the parameter as substring, name: the human readable resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18365,7 +18300,7 @@
             },
             {
               "name": "name_l_starts_with",
-              "description": "name lowercased starts with the parameter value, name: the human readable resource name",
+              "description": "name lower-cased starts with the parameter value, name: the human readable resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18375,7 +18310,7 @@
             },
             {
               "name": "name_l_not_starts_with",
-              "description": "name lowercased doesn't start with the parameter value, name: the human readable resource name",
+              "description": "name lower-cased doesn't start with the parameter value, name: the human readable resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18385,7 +18320,7 @@
             },
             {
               "name": "name_l_ends_with",
-              "description": "name lowercased ends with the parameter value, name: the human readable resource name",
+              "description": "name lower-cased ends with the parameter value, name: the human readable resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18395,7 +18330,7 @@
             },
             {
               "name": "name_l_not_ends_with",
-              "description": "name lowercased doesn't end with the parameter value, name: the human readable resource name",
+              "description": "name lower-cased doesn't end with the parameter value, name: the human readable resource name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18505,7 +18440,7 @@
             },
             {
               "name": "code_l",
-              "description": "code lowercased equals the parameter, code: the resource identification",
+              "description": "code lower-cased equals the parameter, code: the resource identification",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18515,7 +18450,7 @@
             },
             {
               "name": "code_l_not",
-              "description": "code lowercased doesn't equal the parameter, code: the resource identification",
+              "description": "code lower-cased doesn't equal the parameter, code: the resource identification",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18525,7 +18460,7 @@
             },
             {
               "name": "code_l_in",
-              "description": "code lowercased is a substring of the parameter, code: the resource identification",
+              "description": "code lower-cased is a substring of the parameter, code: the resource identification",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18535,7 +18470,7 @@
             },
             {
               "name": "code_l_not_in",
-              "description": "code lowercased is not a substring of the parameter, code: the resource identification",
+              "description": "code lower-cased is not a substring of the parameter, code: the resource identification",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18545,7 +18480,7 @@
             },
             {
               "name": "code_l_contains",
-              "description": "code lowercased contains the parameter as substring, code: the resource identification",
+              "description": "code lower-cased contains the parameter as substring, code: the resource identification",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18555,7 +18490,7 @@
             },
             {
               "name": "code_l_not_contains",
-              "description": "code lowercased doesn't contain the parameter as substring, code: the resource identification",
+              "description": "code lower-cased doesn't contain the parameter as substring, code: the resource identification",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18565,7 +18500,7 @@
             },
             {
               "name": "code_l_starts_with",
-              "description": "code lowercased starts with the parameter value, code: the resource identification",
+              "description": "code lower-cased starts with the parameter value, code: the resource identification",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18575,7 +18510,7 @@
             },
             {
               "name": "code_l_not_starts_with",
-              "description": "code lowercased doesn't start with the parameter value, code: the resource identification",
+              "description": "code lower-cased doesn't start with the parameter value, code: the resource identification",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18585,7 +18520,7 @@
             },
             {
               "name": "code_l_ends_with",
-              "description": "code lowercased ends with the parameter value, code: the resource identification",
+              "description": "code lower-cased ends with the parameter value, code: the resource identification",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18595,7 +18530,7 @@
             },
             {
               "name": "code_l_not_ends_with",
-              "description": "code lowercased doesn't end with the parameter value, code: the resource identification",
+              "description": "code lower-cased doesn't end with the parameter value, code: the resource identification",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18705,7 +18640,7 @@
             },
             {
               "name": "currentPoint_l",
-              "description": "currentPoint lowercased equals the parameter, currentPoint: the current migration point of the resource",
+              "description": "currentPoint lower-cased equals the parameter, currentPoint: the current migration point of the resource",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18715,7 +18650,7 @@
             },
             {
               "name": "currentPoint_l_not",
-              "description": "currentPoint lowercased doesn't equal the parameter, currentPoint: the current migration point of the resource",
+              "description": "currentPoint lower-cased doesn't equal the parameter, currentPoint: the current migration point of the resource",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18725,7 +18660,7 @@
             },
             {
               "name": "currentPoint_l_in",
-              "description": "currentPoint lowercased is a substring of the parameter, currentPoint: the current migration point of the resource",
+              "description": "currentPoint lower-cased is a substring of the parameter, currentPoint: the current migration point of the resource",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18735,7 +18670,7 @@
             },
             {
               "name": "currentPoint_l_not_in",
-              "description": "currentPoint lowercased is not a substring of the parameter, currentPoint: the current migration point of the resource",
+              "description": "currentPoint lower-cased is not a substring of the parameter, currentPoint: the current migration point of the resource",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18745,7 +18680,7 @@
             },
             {
               "name": "currentPoint_l_contains",
-              "description": "currentPoint lowercased contains the parameter as substring, currentPoint: the current migration point of the resource",
+              "description": "currentPoint lower-cased contains the parameter as substring, currentPoint: the current migration point of the resource",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18755,7 +18690,7 @@
             },
             {
               "name": "currentPoint_l_not_contains",
-              "description": "currentPoint lowercased doesn't contain the parameter as substring, currentPoint: the current migration point of the resource",
+              "description": "currentPoint lower-cased doesn't contain the parameter as substring, currentPoint: the current migration point of the resource",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18765,7 +18700,7 @@
             },
             {
               "name": "currentPoint_l_starts_with",
-              "description": "currentPoint lowercased starts with the parameter value, currentPoint: the current migration point of the resource",
+              "description": "currentPoint lower-cased starts with the parameter value, currentPoint: the current migration point of the resource",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18775,7 +18710,7 @@
             },
             {
               "name": "currentPoint_l_not_starts_with",
-              "description": "currentPoint lowercased doesn't start with the parameter value, currentPoint: the current migration point of the resource",
+              "description": "currentPoint lower-cased doesn't start with the parameter value, currentPoint: the current migration point of the resource",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18785,7 +18720,7 @@
             },
             {
               "name": "currentPoint_l_ends_with",
-              "description": "currentPoint lowercased ends with the parameter value, currentPoint: the current migration point of the resource",
+              "description": "currentPoint lower-cased ends with the parameter value, currentPoint: the current migration point of the resource",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18795,7 +18730,7 @@
             },
             {
               "name": "currentPoint_l_not_ends_with",
-              "description": "currentPoint lowercased doesn't end with the parameter value, currentPoint: the current migration point of the resource",
+              "description": "currentPoint lower-cased doesn't end with the parameter value, currentPoint: the current migration point of the resource",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18925,7 +18860,7 @@
             },
             {
               "name": "templateCode_l",
-              "description": "templateCode lowercased equals the parameter, templateCode: The code of migrator template",
+              "description": "templateCode lower-cased equals the parameter, templateCode: The code of migrator template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18935,7 +18870,7 @@
             },
             {
               "name": "templateCode_l_not",
-              "description": "templateCode lowercased doesn't equal the parameter, templateCode: The code of migrator template",
+              "description": "templateCode lower-cased doesn't equal the parameter, templateCode: The code of migrator template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18945,7 +18880,7 @@
             },
             {
               "name": "templateCode_l_in",
-              "description": "templateCode lowercased is a substring of the parameter, templateCode: The code of migrator template",
+              "description": "templateCode lower-cased is a substring of the parameter, templateCode: The code of migrator template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18955,7 +18890,7 @@
             },
             {
               "name": "templateCode_l_not_in",
-              "description": "templateCode lowercased is not a substring of the parameter, templateCode: The code of migrator template",
+              "description": "templateCode lower-cased is not a substring of the parameter, templateCode: The code of migrator template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18965,7 +18900,7 @@
             },
             {
               "name": "templateCode_l_contains",
-              "description": "templateCode lowercased contains the parameter as substring, templateCode: The code of migrator template",
+              "description": "templateCode lower-cased contains the parameter as substring, templateCode: The code of migrator template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18975,7 +18910,7 @@
             },
             {
               "name": "templateCode_l_not_contains",
-              "description": "templateCode lowercased doesn't contain the parameter as substring, templateCode: The code of migrator template",
+              "description": "templateCode lower-cased doesn't contain the parameter as substring, templateCode: The code of migrator template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18985,7 +18920,7 @@
             },
             {
               "name": "templateCode_l_starts_with",
-              "description": "templateCode lowercased starts with the parameter value, templateCode: The code of migrator template",
+              "description": "templateCode lower-cased starts with the parameter value, templateCode: The code of migrator template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -18995,7 +18930,7 @@
             },
             {
               "name": "templateCode_l_not_starts_with",
-              "description": "templateCode lowercased doesn't start with the parameter value, templateCode: The code of migrator template",
+              "description": "templateCode lower-cased doesn't start with the parameter value, templateCode: The code of migrator template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19005,7 +18940,7 @@
             },
             {
               "name": "templateCode_l_ends_with",
-              "description": "templateCode lowercased ends with the parameter value, templateCode: The code of migrator template",
+              "description": "templateCode lower-cased ends with the parameter value, templateCode: The code of migrator template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19015,7 +18950,7 @@
             },
             {
               "name": "templateCode_l_not_ends_with",
-              "description": "templateCode lowercased doesn't end with the parameter value, templateCode: The code of migrator template",
+              "description": "templateCode lower-cased doesn't end with the parameter value, templateCode: The code of migrator template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19125,7 +19060,7 @@
             },
             {
               "name": "migratorTypeName_l",
-              "description": "migratorTypeName lowercased equals the parameter, migratorTypeName: The type name of the migrator",
+              "description": "migratorTypeName lower-cased equals the parameter, migratorTypeName: The type name of the migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19135,7 +19070,7 @@
             },
             {
               "name": "migratorTypeName_l_not",
-              "description": "migratorTypeName lowercased doesn't equal the parameter, migratorTypeName: The type name of the migrator",
+              "description": "migratorTypeName lower-cased doesn't equal the parameter, migratorTypeName: The type name of the migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19145,7 +19080,7 @@
             },
             {
               "name": "migratorTypeName_l_in",
-              "description": "migratorTypeName lowercased is a substring of the parameter, migratorTypeName: The type name of the migrator",
+              "description": "migratorTypeName lower-cased is a substring of the parameter, migratorTypeName: The type name of the migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19155,7 +19090,7 @@
             },
             {
               "name": "migratorTypeName_l_not_in",
-              "description": "migratorTypeName lowercased is not a substring of the parameter, migratorTypeName: The type name of the migrator",
+              "description": "migratorTypeName lower-cased is not a substring of the parameter, migratorTypeName: The type name of the migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19165,7 +19100,7 @@
             },
             {
               "name": "migratorTypeName_l_contains",
-              "description": "migratorTypeName lowercased contains the parameter as substring, migratorTypeName: The type name of the migrator",
+              "description": "migratorTypeName lower-cased contains the parameter as substring, migratorTypeName: The type name of the migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19175,7 +19110,7 @@
             },
             {
               "name": "migratorTypeName_l_not_contains",
-              "description": "migratorTypeName lowercased doesn't contain the parameter as substring, migratorTypeName: The type name of the migrator",
+              "description": "migratorTypeName lower-cased doesn't contain the parameter as substring, migratorTypeName: The type name of the migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19185,7 +19120,7 @@
             },
             {
               "name": "migratorTypeName_l_starts_with",
-              "description": "migratorTypeName lowercased starts with the parameter value, migratorTypeName: The type name of the migrator",
+              "description": "migratorTypeName lower-cased starts with the parameter value, migratorTypeName: The type name of the migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19195,7 +19130,7 @@
             },
             {
               "name": "migratorTypeName_l_not_starts_with",
-              "description": "migratorTypeName lowercased doesn't start with the parameter value, migratorTypeName: The type name of the migrator",
+              "description": "migratorTypeName lower-cased doesn't start with the parameter value, migratorTypeName: The type name of the migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19205,7 +19140,7 @@
             },
             {
               "name": "migratorTypeName_l_ends_with",
-              "description": "migratorTypeName lowercased ends with the parameter value, migratorTypeName: The type name of the migrator",
+              "description": "migratorTypeName lower-cased ends with the parameter value, migratorTypeName: The type name of the migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19215,7 +19150,7 @@
             },
             {
               "name": "migratorTypeName_l_not_ends_with",
-              "description": "migratorTypeName lowercased doesn't end with the parameter value, migratorTypeName: The type name of the migrator",
+              "description": "migratorTypeName lower-cased doesn't end with the parameter value, migratorTypeName: The type name of the migrator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19230,20 +19165,20 @@
         },
         {
           "kind": "ENUM",
-          "name": "KlusterKiteNodeApi_MigratorConfigurationState_Sort",
+          "name": "KlusterKiteNodeApi_ResourceConfigurationState_Sort",
           "description": null,
           "fields": null,
           "inputFields": null,
           "interfaces": null,
           "enumValues": [
             {
-              "name": "typeName_asc",
+              "name": "key_asc",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "typeName_desc",
+              "name": "key_desc",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -19261,37 +19196,61 @@
               "deprecationReason": null
             },
             {
-              "name": "lastDefinedPoint_asc",
+              "name": "code_asc",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "lastDefinedPoint_desc",
+              "name": "code_desc",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "dependencyType_asc",
+              "name": "currentPoint_asc",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "dependencyType_desc",
+              "name": "currentPoint_desc",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "priority_asc",
+              "name": "position_asc",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "priority_desc",
+              "name": "position_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "templateCode_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "templateCode_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "migratorTypeName_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "migratorTypeName_desc",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -19427,7 +19386,7 @@
             },
             {
               "name": "typeName_l",
-              "description": "typeName lowercased equals the parameter, typeName: the migrator type name",
+              "description": "typeName lower-cased equals the parameter, typeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19437,7 +19396,7 @@
             },
             {
               "name": "typeName_l_not",
-              "description": "typeName lowercased doesn't equal the parameter, typeName: the migrator type name",
+              "description": "typeName lower-cased doesn't equal the parameter, typeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19447,7 +19406,7 @@
             },
             {
               "name": "typeName_l_in",
-              "description": "typeName lowercased is a substring of the parameter, typeName: the migrator type name",
+              "description": "typeName lower-cased is a substring of the parameter, typeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19457,7 +19416,7 @@
             },
             {
               "name": "typeName_l_not_in",
-              "description": "typeName lowercased is not a substring of the parameter, typeName: the migrator type name",
+              "description": "typeName lower-cased is not a substring of the parameter, typeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19467,7 +19426,7 @@
             },
             {
               "name": "typeName_l_contains",
-              "description": "typeName lowercased contains the parameter as substring, typeName: the migrator type name",
+              "description": "typeName lower-cased contains the parameter as substring, typeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19477,7 +19436,7 @@
             },
             {
               "name": "typeName_l_not_contains",
-              "description": "typeName lowercased doesn't contain the parameter as substring, typeName: the migrator type name",
+              "description": "typeName lower-cased doesn't contain the parameter as substring, typeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19487,7 +19446,7 @@
             },
             {
               "name": "typeName_l_starts_with",
-              "description": "typeName lowercased starts with the parameter value, typeName: the migrator type name",
+              "description": "typeName lower-cased starts with the parameter value, typeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19497,7 +19456,7 @@
             },
             {
               "name": "typeName_l_not_starts_with",
-              "description": "typeName lowercased doesn't start with the parameter value, typeName: the migrator type name",
+              "description": "typeName lower-cased doesn't start with the parameter value, typeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19507,7 +19466,7 @@
             },
             {
               "name": "typeName_l_ends_with",
-              "description": "typeName lowercased ends with the parameter value, typeName: the migrator type name",
+              "description": "typeName lower-cased ends with the parameter value, typeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19517,7 +19476,7 @@
             },
             {
               "name": "typeName_l_not_ends_with",
-              "description": "typeName lowercased doesn't end with the parameter value, typeName: the migrator type name",
+              "description": "typeName lower-cased doesn't end with the parameter value, typeName: the migrator type name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19627,7 +19586,7 @@
             },
             {
               "name": "name_l",
-              "description": "name lowercased equals the parameter, name: the migrator name",
+              "description": "name lower-cased equals the parameter, name: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19637,7 +19596,7 @@
             },
             {
               "name": "name_l_not",
-              "description": "name lowercased doesn't equal the parameter, name: the migrator name",
+              "description": "name lower-cased doesn't equal the parameter, name: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19647,7 +19606,7 @@
             },
             {
               "name": "name_l_in",
-              "description": "name lowercased is a substring of the parameter, name: the migrator name",
+              "description": "name lower-cased is a substring of the parameter, name: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19657,7 +19616,7 @@
             },
             {
               "name": "name_l_not_in",
-              "description": "name lowercased is not a substring of the parameter, name: the migrator name",
+              "description": "name lower-cased is not a substring of the parameter, name: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19667,7 +19626,7 @@
             },
             {
               "name": "name_l_contains",
-              "description": "name lowercased contains the parameter as substring, name: the migrator name",
+              "description": "name lower-cased contains the parameter as substring, name: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19677,7 +19636,7 @@
             },
             {
               "name": "name_l_not_contains",
-              "description": "name lowercased doesn't contain the parameter as substring, name: the migrator name",
+              "description": "name lower-cased doesn't contain the parameter as substring, name: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19687,7 +19646,7 @@
             },
             {
               "name": "name_l_starts_with",
-              "description": "name lowercased starts with the parameter value, name: the migrator name",
+              "description": "name lower-cased starts with the parameter value, name: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19697,7 +19656,7 @@
             },
             {
               "name": "name_l_not_starts_with",
-              "description": "name lowercased doesn't start with the parameter value, name: the migrator name",
+              "description": "name lower-cased doesn't start with the parameter value, name: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19707,7 +19666,7 @@
             },
             {
               "name": "name_l_ends_with",
-              "description": "name lowercased ends with the parameter value, name: the migrator name",
+              "description": "name lower-cased ends with the parameter value, name: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19717,7 +19676,7 @@
             },
             {
               "name": "name_l_not_ends_with",
-              "description": "name lowercased doesn't end with the parameter value, name: the migrator name",
+              "description": "name lower-cased doesn't end with the parameter value, name: the migrator name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19827,7 +19786,7 @@
             },
             {
               "name": "lastDefinedPoint_l",
-              "description": "lastDefinedPoint lowercased equals the parameter, lastDefinedPoint: the last defined point for current configuration",
+              "description": "lastDefinedPoint lower-cased equals the parameter, lastDefinedPoint: the last defined point for current configuration",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19837,7 +19796,7 @@
             },
             {
               "name": "lastDefinedPoint_l_not",
-              "description": "lastDefinedPoint lowercased doesn't equal the parameter, lastDefinedPoint: the last defined point for current configuration",
+              "description": "lastDefinedPoint lower-cased doesn't equal the parameter, lastDefinedPoint: the last defined point for current configuration",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19847,7 +19806,7 @@
             },
             {
               "name": "lastDefinedPoint_l_in",
-              "description": "lastDefinedPoint lowercased is a substring of the parameter, lastDefinedPoint: the last defined point for current configuration",
+              "description": "lastDefinedPoint lower-cased is a substring of the parameter, lastDefinedPoint: the last defined point for current configuration",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19857,7 +19816,7 @@
             },
             {
               "name": "lastDefinedPoint_l_not_in",
-              "description": "lastDefinedPoint lowercased is not a substring of the parameter, lastDefinedPoint: the last defined point for current configuration",
+              "description": "lastDefinedPoint lower-cased is not a substring of the parameter, lastDefinedPoint: the last defined point for current configuration",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19867,7 +19826,7 @@
             },
             {
               "name": "lastDefinedPoint_l_contains",
-              "description": "lastDefinedPoint lowercased contains the parameter as substring, lastDefinedPoint: the last defined point for current configuration",
+              "description": "lastDefinedPoint lower-cased contains the parameter as substring, lastDefinedPoint: the last defined point for current configuration",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19877,7 +19836,7 @@
             },
             {
               "name": "lastDefinedPoint_l_not_contains",
-              "description": "lastDefinedPoint lowercased doesn't contain the parameter as substring, lastDefinedPoint: the last defined point for current configuration",
+              "description": "lastDefinedPoint lower-cased doesn't contain the parameter as substring, lastDefinedPoint: the last defined point for current configuration",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19887,7 +19846,7 @@
             },
             {
               "name": "lastDefinedPoint_l_starts_with",
-              "description": "lastDefinedPoint lowercased starts with the parameter value, lastDefinedPoint: the last defined point for current configuration",
+              "description": "lastDefinedPoint lower-cased starts with the parameter value, lastDefinedPoint: the last defined point for current configuration",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19897,7 +19856,7 @@
             },
             {
               "name": "lastDefinedPoint_l_not_starts_with",
-              "description": "lastDefinedPoint lowercased doesn't start with the parameter value, lastDefinedPoint: the last defined point for current configuration",
+              "description": "lastDefinedPoint lower-cased doesn't start with the parameter value, lastDefinedPoint: the last defined point for current configuration",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19907,7 +19866,7 @@
             },
             {
               "name": "lastDefinedPoint_l_ends_with",
-              "description": "lastDefinedPoint lowercased ends with the parameter value, lastDefinedPoint: the last defined point for current configuration",
+              "description": "lastDefinedPoint lower-cased ends with the parameter value, lastDefinedPoint: the last defined point for current configuration",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -19917,7 +19876,7 @@
             },
             {
               "name": "lastDefinedPoint_l_not_ends_with",
-              "description": "lastDefinedPoint lowercased doesn't end with the parameter value, lastDefinedPoint: the last defined point for current configuration",
+              "description": "lastDefinedPoint lower-cased doesn't end with the parameter value, lastDefinedPoint: the last defined point for current configuration",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -20012,20 +19971,68 @@
         },
         {
           "kind": "ENUM",
-          "name": "KlusterKiteNodeApi_MigratorTemplateConfigurationState_Sort",
+          "name": "KlusterKiteNodeApi_MigratorConfigurationState_Sort",
           "description": null,
           "fields": null,
           "inputFields": null,
           "interfaces": null,
           "enumValues": [
             {
-              "name": "code_asc",
+              "name": "typeName_asc",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "code_desc",
+              "name": "typeName_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lastDefinedPoint_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lastDefinedPoint_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dependencyType_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dependencyType_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "priority_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "priority_desc",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -20161,7 +20168,7 @@
             },
             {
               "name": "code_l",
-              "description": "code lowercased equals the parameter, code: the template code",
+              "description": "code lower-cased equals the parameter, code: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -20171,7 +20178,7 @@
             },
             {
               "name": "code_l_not",
-              "description": "code lowercased doesn't equal the parameter, code: the template code",
+              "description": "code lower-cased doesn't equal the parameter, code: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -20181,7 +20188,7 @@
             },
             {
               "name": "code_l_in",
-              "description": "code lowercased is a substring of the parameter, code: the template code",
+              "description": "code lower-cased is a substring of the parameter, code: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -20191,7 +20198,7 @@
             },
             {
               "name": "code_l_not_in",
-              "description": "code lowercased is not a substring of the parameter, code: the template code",
+              "description": "code lower-cased is not a substring of the parameter, code: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -20201,7 +20208,7 @@
             },
             {
               "name": "code_l_contains",
-              "description": "code lowercased contains the parameter as substring, code: the template code",
+              "description": "code lower-cased contains the parameter as substring, code: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -20211,7 +20218,7 @@
             },
             {
               "name": "code_l_not_contains",
-              "description": "code lowercased doesn't contain the parameter as substring, code: the template code",
+              "description": "code lower-cased doesn't contain the parameter as substring, code: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -20221,7 +20228,7 @@
             },
             {
               "name": "code_l_starts_with",
-              "description": "code lowercased starts with the parameter value, code: the template code",
+              "description": "code lower-cased starts with the parameter value, code: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -20231,7 +20238,7 @@
             },
             {
               "name": "code_l_not_starts_with",
-              "description": "code lowercased doesn't start with the parameter value, code: the template code",
+              "description": "code lower-cased doesn't start with the parameter value, code: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -20241,7 +20248,7 @@
             },
             {
               "name": "code_l_ends_with",
-              "description": "code lowercased ends with the parameter value, code: the template code",
+              "description": "code lower-cased ends with the parameter value, code: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -20251,7 +20258,7 @@
             },
             {
               "name": "code_l_not_ends_with",
-              "description": "code lowercased doesn't end with the parameter value, code: the template code",
+              "description": "code lower-cased doesn't end with the parameter value, code: the template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -20262,6 +20269,29 @@
           ],
           "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "KlusterKiteNodeApi_MigratorTemplateConfigurationState_Sort",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "code_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "code_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -20388,7 +20418,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -20400,7 +20430,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -20410,6 +20440,16 @@
               "name": "logs",
               "description": "the list of migration logs",
               "args": [
+                {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
                 {
                   "name": "limit",
                   "description": null,
@@ -20421,11 +20461,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_MigrationLogRecord_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -20445,17 +20485,7 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_MigrationLogRecord_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -20523,7 +20553,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -20609,7 +20639,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -20650,7 +20680,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -20731,7 +20761,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -20740,53 +20770,6 @@
               "ofType": null
             }
           ]
-        },
-        {
-          "kind": "ENUM",
-          "name": "KlusterKiteNodeApi_NugetPackageFamily_Sort",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "id_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "version_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "version_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
         },
         {
           "kind": "INPUT_OBJECT",
@@ -20916,7 +20899,7 @@
             },
             {
               "name": "id_l",
-              "description": "id lowercased equals the parameter, id: The package id (name and version)",
+              "description": "id lower-cased equals the parameter, id: The package id (name and version)",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -20926,7 +20909,7 @@
             },
             {
               "name": "id_l_not",
-              "description": "id lowercased doesn't equal the parameter, id: The package id (name and version)",
+              "description": "id lower-cased doesn't equal the parameter, id: The package id (name and version)",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -20936,7 +20919,7 @@
             },
             {
               "name": "id_l_in",
-              "description": "id lowercased is a substring of the parameter, id: The package id (name and version)",
+              "description": "id lower-cased is a substring of the parameter, id: The package id (name and version)",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -20946,7 +20929,7 @@
             },
             {
               "name": "id_l_not_in",
-              "description": "id lowercased is not a substring of the parameter, id: The package id (name and version)",
+              "description": "id lower-cased is not a substring of the parameter, id: The package id (name and version)",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -20956,7 +20939,7 @@
             },
             {
               "name": "id_l_contains",
-              "description": "id lowercased contains the parameter as substring, id: The package id (name and version)",
+              "description": "id lower-cased contains the parameter as substring, id: The package id (name and version)",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -20966,7 +20949,7 @@
             },
             {
               "name": "id_l_not_contains",
-              "description": "id lowercased doesn't contain the parameter as substring, id: The package id (name and version)",
+              "description": "id lower-cased doesn't contain the parameter as substring, id: The package id (name and version)",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -20976,7 +20959,7 @@
             },
             {
               "name": "id_l_starts_with",
-              "description": "id lowercased starts with the parameter value, id: The package id (name and version)",
+              "description": "id lower-cased starts with the parameter value, id: The package id (name and version)",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -20986,7 +20969,7 @@
             },
             {
               "name": "id_l_not_starts_with",
-              "description": "id lowercased doesn't start with the parameter value, id: The package id (name and version)",
+              "description": "id lower-cased doesn't start with the parameter value, id: The package id (name and version)",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -20996,7 +20979,7 @@
             },
             {
               "name": "id_l_ends_with",
-              "description": "id lowercased ends with the parameter value, id: The package id (name and version)",
+              "description": "id lower-cased ends with the parameter value, id: The package id (name and version)",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -21006,7 +20989,7 @@
             },
             {
               "name": "id_l_not_ends_with",
-              "description": "id lowercased doesn't end with the parameter value, id: The package id (name and version)",
+              "description": "id lower-cased doesn't end with the parameter value, id: The package id (name and version)",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -21116,7 +21099,7 @@
             },
             {
               "name": "name_l",
-              "description": "name lowercased equals the parameter, name: The package name",
+              "description": "name lower-cased equals the parameter, name: The package name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -21126,7 +21109,7 @@
             },
             {
               "name": "name_l_not",
-              "description": "name lowercased doesn't equal the parameter, name: The package name",
+              "description": "name lower-cased doesn't equal the parameter, name: The package name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -21136,7 +21119,7 @@
             },
             {
               "name": "name_l_in",
-              "description": "name lowercased is a substring of the parameter, name: The package name",
+              "description": "name lower-cased is a substring of the parameter, name: The package name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -21146,7 +21129,7 @@
             },
             {
               "name": "name_l_not_in",
-              "description": "name lowercased is not a substring of the parameter, name: The package name",
+              "description": "name lower-cased is not a substring of the parameter, name: The package name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -21156,7 +21139,7 @@
             },
             {
               "name": "name_l_contains",
-              "description": "name lowercased contains the parameter as substring, name: The package name",
+              "description": "name lower-cased contains the parameter as substring, name: The package name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -21166,7 +21149,7 @@
             },
             {
               "name": "name_l_not_contains",
-              "description": "name lowercased doesn't contain the parameter as substring, name: The package name",
+              "description": "name lower-cased doesn't contain the parameter as substring, name: The package name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -21176,7 +21159,7 @@
             },
             {
               "name": "name_l_starts_with",
-              "description": "name lowercased starts with the parameter value, name: The package name",
+              "description": "name lower-cased starts with the parameter value, name: The package name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -21186,7 +21169,7 @@
             },
             {
               "name": "name_l_not_starts_with",
-              "description": "name lowercased doesn't start with the parameter value, name: The package name",
+              "description": "name lower-cased doesn't start with the parameter value, name: The package name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -21196,7 +21179,7 @@
             },
             {
               "name": "name_l_ends_with",
-              "description": "name lowercased ends with the parameter value, name: The package name",
+              "description": "name lower-cased ends with the parameter value, name: The package name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -21206,7 +21189,7 @@
             },
             {
               "name": "name_l_not_ends_with",
-              "description": "name lowercased doesn't end with the parameter value, name: The package name",
+              "description": "name lower-cased doesn't end with the parameter value, name: The package name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -21316,7 +21299,7 @@
             },
             {
               "name": "version_l",
-              "description": "version lowercased equals the parameter, version: The package version",
+              "description": "version lower-cased equals the parameter, version: The package version",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -21326,7 +21309,7 @@
             },
             {
               "name": "version_l_not",
-              "description": "version lowercased doesn't equal the parameter, version: The package version",
+              "description": "version lower-cased doesn't equal the parameter, version: The package version",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -21336,7 +21319,7 @@
             },
             {
               "name": "version_l_in",
-              "description": "version lowercased is a substring of the parameter, version: The package version",
+              "description": "version lower-cased is a substring of the parameter, version: The package version",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -21346,7 +21329,7 @@
             },
             {
               "name": "version_l_not_in",
-              "description": "version lowercased is not a substring of the parameter, version: The package version",
+              "description": "version lower-cased is not a substring of the parameter, version: The package version",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -21356,7 +21339,7 @@
             },
             {
               "name": "version_l_contains",
-              "description": "version lowercased contains the parameter as substring, version: The package version",
+              "description": "version lower-cased contains the parameter as substring, version: The package version",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -21366,7 +21349,7 @@
             },
             {
               "name": "version_l_not_contains",
-              "description": "version lowercased doesn't contain the parameter as substring, version: The package version",
+              "description": "version lower-cased doesn't contain the parameter as substring, version: The package version",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -21376,7 +21359,7 @@
             },
             {
               "name": "version_l_starts_with",
-              "description": "version lowercased starts with the parameter value, version: The package version",
+              "description": "version lower-cased starts with the parameter value, version: The package version",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -21386,7 +21369,7 @@
             },
             {
               "name": "version_l_not_starts_with",
-              "description": "version lowercased doesn't start with the parameter value, version: The package version",
+              "description": "version lower-cased doesn't start with the parameter value, version: The package version",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -21396,7 +21379,7 @@
             },
             {
               "name": "version_l_ends_with",
-              "description": "version lowercased ends with the parameter value, version: The package version",
+              "description": "version lower-cased ends with the parameter value, version: The package version",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -21406,7 +21389,7 @@
             },
             {
               "name": "version_l_not_ends_with",
-              "description": "version lowercased doesn't end with the parameter value, version: The package version",
+              "description": "version lower-cased doesn't end with the parameter value, version: The package version",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -21417,6 +21400,53 @@
           ],
           "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "KlusterKiteNodeApi_NugetPackageFamily_Sort",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "id_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "version_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "version_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -21454,7 +21484,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -21495,7 +21525,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -21591,6 +21621,16 @@
               "description": "the list of descriptions of installed modules",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -21601,11 +21641,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_PackageDescription_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -21625,21 +21665,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_PackageDescription_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -21671,7 +21701,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -21723,7 +21753,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Long",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -21731,7 +21761,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -21820,7 +21850,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -21832,8 +21862,8 @@
         },
         {
           "kind": "SCALAR",
-          "name": "Uid",
-          "description": "The Uid / Guid representation",
+          "name": "Guid",
+          "description": null,
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -21841,110 +21871,13 @@
           "possibleTypes": null
         },
         {
-          "kind": "ENUM",
-          "name": "KlusterKiteNodeApi_NodeDescription_Sort",
+          "kind": "SCALAR",
+          "name": "Long",
           "description": null,
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "enumValues": [
-            {
-              "name": "containerType_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "containerType_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "isClusterLeader_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "isClusterLeader_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "isObsolete_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "isObsolete_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "isInitialized_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "isInitialized_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "nodeId_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "nodeId_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "nodeTemplate_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "nodeTemplate_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "configurationId_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "configurationId_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "startTimeStamp_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "startTimeStamp_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
+          "enumValues": null,
           "possibleTypes": null
         },
         {
@@ -22075,7 +22008,7 @@
             },
             {
               "name": "containerType_l",
-              "description": "containerType lowercased equals the parameter, containerType: symbolic container type code",
+              "description": "containerType lower-cased equals the parameter, containerType: symbolic container type code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -22085,7 +22018,7 @@
             },
             {
               "name": "containerType_l_not",
-              "description": "containerType lowercased doesn't equal the parameter, containerType: symbolic container type code",
+              "description": "containerType lower-cased doesn't equal the parameter, containerType: symbolic container type code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -22095,7 +22028,7 @@
             },
             {
               "name": "containerType_l_in",
-              "description": "containerType lowercased is a substring of the parameter, containerType: symbolic container type code",
+              "description": "containerType lower-cased is a substring of the parameter, containerType: symbolic container type code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -22105,7 +22038,7 @@
             },
             {
               "name": "containerType_l_not_in",
-              "description": "containerType lowercased is not a substring of the parameter, containerType: symbolic container type code",
+              "description": "containerType lower-cased is not a substring of the parameter, containerType: symbolic container type code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -22115,7 +22048,7 @@
             },
             {
               "name": "containerType_l_contains",
-              "description": "containerType lowercased contains the parameter as substring, containerType: symbolic container type code",
+              "description": "containerType lower-cased contains the parameter as substring, containerType: symbolic container type code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -22125,7 +22058,7 @@
             },
             {
               "name": "containerType_l_not_contains",
-              "description": "containerType lowercased doesn't contain the parameter as substring, containerType: symbolic container type code",
+              "description": "containerType lower-cased doesn't contain the parameter as substring, containerType: symbolic container type code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -22135,7 +22068,7 @@
             },
             {
               "name": "containerType_l_starts_with",
-              "description": "containerType lowercased starts with the parameter value, containerType: symbolic container type code",
+              "description": "containerType lower-cased starts with the parameter value, containerType: symbolic container type code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -22145,7 +22078,7 @@
             },
             {
               "name": "containerType_l_not_starts_with",
-              "description": "containerType lowercased doesn't start with the parameter value, containerType: symbolic container type code",
+              "description": "containerType lower-cased doesn't start with the parameter value, containerType: symbolic container type code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -22155,7 +22088,7 @@
             },
             {
               "name": "containerType_l_ends_with",
-              "description": "containerType lowercased ends with the parameter value, containerType: symbolic container type code",
+              "description": "containerType lower-cased ends with the parameter value, containerType: symbolic container type code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -22165,7 +22098,7 @@
             },
             {
               "name": "containerType_l_not_ends_with",
-              "description": "containerType lowercased doesn't end with the parameter value, containerType: symbolic container type code",
+              "description": "containerType lower-cased doesn't end with the parameter value, containerType: symbolic container type code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -22238,7 +22171,7 @@
               "description": "nodeId exactly equals to the parameter, nodeId: request id to indicate node instance startup",
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -22248,7 +22181,7 @@
               "description": "nodeId not equals to the parameter, nodeId: request id to indicate node instance startup",
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -22355,7 +22288,7 @@
             },
             {
               "name": "nodeTemplate_l",
-              "description": "nodeTemplate lowercased equals the parameter, nodeTemplate: node template code",
+              "description": "nodeTemplate lower-cased equals the parameter, nodeTemplate: node template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -22365,7 +22298,7 @@
             },
             {
               "name": "nodeTemplate_l_not",
-              "description": "nodeTemplate lowercased doesn't equal the parameter, nodeTemplate: node template code",
+              "description": "nodeTemplate lower-cased doesn't equal the parameter, nodeTemplate: node template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -22375,7 +22308,7 @@
             },
             {
               "name": "nodeTemplate_l_in",
-              "description": "nodeTemplate lowercased is a substring of the parameter, nodeTemplate: node template code",
+              "description": "nodeTemplate lower-cased is a substring of the parameter, nodeTemplate: node template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -22385,7 +22318,7 @@
             },
             {
               "name": "nodeTemplate_l_not_in",
-              "description": "nodeTemplate lowercased is not a substring of the parameter, nodeTemplate: node template code",
+              "description": "nodeTemplate lower-cased is not a substring of the parameter, nodeTemplate: node template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -22395,7 +22328,7 @@
             },
             {
               "name": "nodeTemplate_l_contains",
-              "description": "nodeTemplate lowercased contains the parameter as substring, nodeTemplate: node template code",
+              "description": "nodeTemplate lower-cased contains the parameter as substring, nodeTemplate: node template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -22405,7 +22338,7 @@
             },
             {
               "name": "nodeTemplate_l_not_contains",
-              "description": "nodeTemplate lowercased doesn't contain the parameter as substring, nodeTemplate: node template code",
+              "description": "nodeTemplate lower-cased doesn't contain the parameter as substring, nodeTemplate: node template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -22415,7 +22348,7 @@
             },
             {
               "name": "nodeTemplate_l_starts_with",
-              "description": "nodeTemplate lowercased starts with the parameter value, nodeTemplate: node template code",
+              "description": "nodeTemplate lower-cased starts with the parameter value, nodeTemplate: node template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -22425,7 +22358,7 @@
             },
             {
               "name": "nodeTemplate_l_not_starts_with",
-              "description": "nodeTemplate lowercased doesn't start with the parameter value, nodeTemplate: node template code",
+              "description": "nodeTemplate lower-cased doesn't start with the parameter value, nodeTemplate: node template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -22435,7 +22368,7 @@
             },
             {
               "name": "nodeTemplate_l_ends_with",
-              "description": "nodeTemplate lowercased ends with the parameter value, nodeTemplate: node template code",
+              "description": "nodeTemplate lower-cased ends with the parameter value, nodeTemplate: node template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -22445,7 +22378,7 @@
             },
             {
               "name": "nodeTemplate_l_not_ends_with",
-              "description": "nodeTemplate lowercased doesn't end with the parameter value, nodeTemplate: node template code",
+              "description": "nodeTemplate lower-cased doesn't end with the parameter value, nodeTemplate: node template code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -22518,7 +22451,7 @@
               "description": "startTimeStamp exactly equals to the parameter, startTimeStamp: node start time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Long",
                 "ofType": null
               },
               "defaultValue": null
@@ -22528,47 +22461,7 @@
               "description": "startTimeStamp not equals to the parameter, startTimeStamp: node start time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "startTimeStamp_lt",
-              "description": "startTimeStamp is less then the parameter, startTimeStamp: node start time",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "startTimeStamp_lte",
-              "description": "startTimeStamp is less then or equal to the parameter, startTimeStamp: node start time",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "startTimeStamp_gt",
-              "description": "startTimeStamp is greater then the parameter, startTimeStamp: node start time",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "startTimeStamp_gte",
-              "description": "startTimeStamp is greater then or equal to the parameter, startTimeStamp: node start time",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
+                "name": "Long",
                 "ofType": null
               },
               "defaultValue": null
@@ -22576,6 +22469,113 @@
           ],
           "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "KlusterKiteNodeApi_NodeDescription_Sort",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "containerType_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "containerType_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isClusterLeader_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isClusterLeader_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isObsolete_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isObsolete_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isInitialized_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isInitialized_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodeId_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodeId_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodeTemplate_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodeTemplate_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "configurationId_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "configurationId_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startTimeStamp_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startTimeStamp_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -22600,6 +22600,16 @@
               "description": "node templates statistics data",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -22610,11 +22620,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_TemplatesStatisticsData_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -22634,21 +22644,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_TemplatesStatisticsData_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -22664,7 +22664,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -22709,7 +22709,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -22750,7 +22750,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -22863,7 +22863,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -22872,101 +22872,6 @@
               "ofType": null
             }
           ]
-        },
-        {
-          "kind": "ENUM",
-          "name": "KlusterKiteNodeApi_TemplatesStatisticsData_Sort",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "activeNodes_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "activeNodes_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "maximumRequiredNodes_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "maximumRequiredNodes_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "minimumRequiredNodes_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "minimumRequiredNodes_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "obsoleteNodes_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "obsoleteNodes_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "startingNodes_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "startingNodes_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "upgradingNodes_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "upgradingNodes_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
         },
         {
           "kind": "INPUT_OBJECT",
@@ -23276,7 +23181,7 @@
             },
             {
               "name": "name_l",
-              "description": "name lowercased equals the parameter, name: name of the node template",
+              "description": "name lower-cased equals the parameter, name: name of the node template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -23286,7 +23191,7 @@
             },
             {
               "name": "name_l_not",
-              "description": "name lowercased doesn't equal the parameter, name: name of the node template",
+              "description": "name lower-cased doesn't equal the parameter, name: name of the node template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -23296,7 +23201,7 @@
             },
             {
               "name": "name_l_in",
-              "description": "name lowercased is a substring of the parameter, name: name of the node template",
+              "description": "name lower-cased is a substring of the parameter, name: name of the node template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -23306,7 +23211,7 @@
             },
             {
               "name": "name_l_not_in",
-              "description": "name lowercased is not a substring of the parameter, name: name of the node template",
+              "description": "name lower-cased is not a substring of the parameter, name: name of the node template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -23316,7 +23221,7 @@
             },
             {
               "name": "name_l_contains",
-              "description": "name lowercased contains the parameter as substring, name: name of the node template",
+              "description": "name lower-cased contains the parameter as substring, name: name of the node template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -23326,7 +23231,7 @@
             },
             {
               "name": "name_l_not_contains",
-              "description": "name lowercased doesn't contain the parameter as substring, name: name of the node template",
+              "description": "name lower-cased doesn't contain the parameter as substring, name: name of the node template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -23336,7 +23241,7 @@
             },
             {
               "name": "name_l_starts_with",
-              "description": "name lowercased starts with the parameter value, name: name of the node template",
+              "description": "name lower-cased starts with the parameter value, name: name of the node template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -23346,7 +23251,7 @@
             },
             {
               "name": "name_l_not_starts_with",
-              "description": "name lowercased doesn't start with the parameter value, name: name of the node template",
+              "description": "name lower-cased doesn't start with the parameter value, name: name of the node template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -23356,7 +23261,7 @@
             },
             {
               "name": "name_l_ends_with",
-              "description": "name lowercased ends with the parameter value, name: name of the node template",
+              "description": "name lower-cased ends with the parameter value, name: name of the node template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -23366,7 +23271,7 @@
             },
             {
               "name": "name_l_not_ends_with",
-              "description": "name lowercased doesn't end with the parameter value, name: name of the node template",
+              "description": "name lower-cased doesn't end with the parameter value, name: name of the node template",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -23560,6 +23465,101 @@
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "KlusterKiteNodeApi_TemplatesStatisticsData_Sort",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "activeNodes_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "activeNodes_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "maximumRequiredNodes_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "maximumRequiredNodes_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "minimumRequiredNodes_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "minimumRequiredNodes_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "obsoleteNodes_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "obsoleteNodes_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startingNodes_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startingNodes_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "upgradingNodes_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "upgradingNodes_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
           "kind": "INTERFACE",
           "name": "IKlusterKiteNodeApi_Migration_Connection",
           "description": "The list of connected KlusterKiteNodeApi_Migration\n The history record describing cluster migration",
@@ -23594,7 +23594,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -23635,7 +23635,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -23644,101 +23644,6 @@
               "ofType": null
             }
           ]
-        },
-        {
-          "kind": "ENUM",
-          "name": "KlusterKiteNodeApi_Migration_Sort",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "id_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "isActive_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "isActive_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "state_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "state_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "started_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "started_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "finished_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "finished_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "fromConfigurationId_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "fromConfigurationId_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "toConfigurationId_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "toConfigurationId_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
         },
         {
           "kind": "INPUT_OBJECT",
@@ -23871,7 +23776,7 @@
               "description": "started exactly equals to the parameter, started: the migration start time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -23881,7 +23786,7 @@
               "description": "started not equals to the parameter, started: the migration start time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -23891,7 +23796,7 @@
               "description": "started is less then the parameter, started: the migration start time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -23901,7 +23806,7 @@
               "description": "started is less then or equal to the parameter, started: the migration start time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -23911,7 +23816,7 @@
               "description": "started is greater then the parameter, started: the migration start time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -23921,7 +23826,7 @@
               "description": "started is greater then or equal to the parameter, started: the migration start time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -23931,7 +23836,7 @@
               "description": "finished exactly equals to the parameter, finished: the migration finish time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -23941,7 +23846,7 @@
               "description": "finished not equals to the parameter, finished: the migration finish time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -23951,7 +23856,7 @@
               "description": "finished is less then the parameter, finished: the migration finish time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -23961,7 +23866,7 @@
               "description": "finished is less then or equal to the parameter, finished: the migration finish time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -23971,7 +23876,7 @@
               "description": "finished is greater then the parameter, finished: the migration finish time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -23981,7 +23886,7 @@
               "description": "finished is greater then or equal to the parameter, finished: the migration finish time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -24112,6 +24017,101 @@
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "KlusterKiteNodeApi_Migration_Sort",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "id_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isActive_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isActive_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "state_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "state_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "started_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "started_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "finished_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "finished_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fromConfigurationId_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fromConfigurationId_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "toConfigurationId_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "toConfigurationId_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
           "kind": "INTERFACE",
           "name": "IKlusterKiteNodeApi_Configuration_Connection",
           "description": "The list of connected KlusterKiteNodeApi_Configuration\n The cluster configuration with all program modules versions, node templates and configurations",
@@ -24146,7 +24146,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -24187,7 +24187,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -24196,137 +24196,6 @@
               "ofType": null
             }
           ]
-        },
-        {
-          "kind": "ENUM",
-          "name": "KlusterKiteNodeApi_Configuration_Sort",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "id_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "majorVersion_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "majorVersion_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "minorVersion_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "minorVersion_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "notes_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "notes_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "created_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "created_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "started_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "started_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "finished_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "finished_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "state_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "state_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "isStable_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "isStable_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
         },
         {
           "kind": "INPUT_OBJECT",
@@ -24636,7 +24505,7 @@
             },
             {
               "name": "name_l",
-              "description": "name lowercased equals the parameter, name: the configuration name",
+              "description": "name lower-cased equals the parameter, name: the configuration name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -24646,7 +24515,7 @@
             },
             {
               "name": "name_l_not",
-              "description": "name lowercased doesn't equal the parameter, name: the configuration name",
+              "description": "name lower-cased doesn't equal the parameter, name: the configuration name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -24656,7 +24525,7 @@
             },
             {
               "name": "name_l_in",
-              "description": "name lowercased is a substring of the parameter, name: the configuration name",
+              "description": "name lower-cased is a substring of the parameter, name: the configuration name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -24666,7 +24535,7 @@
             },
             {
               "name": "name_l_not_in",
-              "description": "name lowercased is not a substring of the parameter, name: the configuration name",
+              "description": "name lower-cased is not a substring of the parameter, name: the configuration name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -24676,7 +24545,7 @@
             },
             {
               "name": "name_l_contains",
-              "description": "name lowercased contains the parameter as substring, name: the configuration name",
+              "description": "name lower-cased contains the parameter as substring, name: the configuration name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -24686,7 +24555,7 @@
             },
             {
               "name": "name_l_not_contains",
-              "description": "name lowercased doesn't contain the parameter as substring, name: the configuration name",
+              "description": "name lower-cased doesn't contain the parameter as substring, name: the configuration name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -24696,7 +24565,7 @@
             },
             {
               "name": "name_l_starts_with",
-              "description": "name lowercased starts with the parameter value, name: the configuration name",
+              "description": "name lower-cased starts with the parameter value, name: the configuration name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -24706,7 +24575,7 @@
             },
             {
               "name": "name_l_not_starts_with",
-              "description": "name lowercased doesn't start with the parameter value, name: the configuration name",
+              "description": "name lower-cased doesn't start with the parameter value, name: the configuration name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -24716,7 +24585,7 @@
             },
             {
               "name": "name_l_ends_with",
-              "description": "name lowercased ends with the parameter value, name: the configuration name",
+              "description": "name lower-cased ends with the parameter value, name: the configuration name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -24726,7 +24595,7 @@
             },
             {
               "name": "name_l_not_ends_with",
-              "description": "name lowercased doesn't end with the parameter value, name: the configuration name",
+              "description": "name lower-cased doesn't end with the parameter value, name: the configuration name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -24836,7 +24705,7 @@
             },
             {
               "name": "notes_l",
-              "description": "notes lowercased equals the parameter, notes: the configuration notes",
+              "description": "notes lower-cased equals the parameter, notes: the configuration notes",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -24846,7 +24715,7 @@
             },
             {
               "name": "notes_l_not",
-              "description": "notes lowercased doesn't equal the parameter, notes: the configuration notes",
+              "description": "notes lower-cased doesn't equal the parameter, notes: the configuration notes",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -24856,7 +24725,7 @@
             },
             {
               "name": "notes_l_in",
-              "description": "notes lowercased is a substring of the parameter, notes: the configuration notes",
+              "description": "notes lower-cased is a substring of the parameter, notes: the configuration notes",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -24866,7 +24735,7 @@
             },
             {
               "name": "notes_l_not_in",
-              "description": "notes lowercased is not a substring of the parameter, notes: the configuration notes",
+              "description": "notes lower-cased is not a substring of the parameter, notes: the configuration notes",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -24876,7 +24745,7 @@
             },
             {
               "name": "notes_l_contains",
-              "description": "notes lowercased contains the parameter as substring, notes: the configuration notes",
+              "description": "notes lower-cased contains the parameter as substring, notes: the configuration notes",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -24886,7 +24755,7 @@
             },
             {
               "name": "notes_l_not_contains",
-              "description": "notes lowercased doesn't contain the parameter as substring, notes: the configuration notes",
+              "description": "notes lower-cased doesn't contain the parameter as substring, notes: the configuration notes",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -24896,7 +24765,7 @@
             },
             {
               "name": "notes_l_starts_with",
-              "description": "notes lowercased starts with the parameter value, notes: the configuration notes",
+              "description": "notes lower-cased starts with the parameter value, notes: the configuration notes",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -24906,7 +24775,7 @@
             },
             {
               "name": "notes_l_not_starts_with",
-              "description": "notes lowercased doesn't start with the parameter value, notes: the configuration notes",
+              "description": "notes lower-cased doesn't start with the parameter value, notes: the configuration notes",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -24916,7 +24785,7 @@
             },
             {
               "name": "notes_l_ends_with",
-              "description": "notes lowercased ends with the parameter value, notes: the configuration notes",
+              "description": "notes lower-cased ends with the parameter value, notes: the configuration notes",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -24926,7 +24795,7 @@
             },
             {
               "name": "notes_l_not_ends_with",
-              "description": "notes lowercased doesn't end with the parameter value, notes: the configuration notes",
+              "description": "notes lower-cased doesn't end with the parameter value, notes: the configuration notes",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -24939,7 +24808,7 @@
               "description": "created exactly equals to the parameter, created: configuration creation date",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -24949,7 +24818,7 @@
               "description": "created not equals to the parameter, created: configuration creation date",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -24959,7 +24828,7 @@
               "description": "created is less then the parameter, created: configuration creation date",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -24969,7 +24838,7 @@
               "description": "created is less then or equal to the parameter, created: configuration creation date",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -24979,7 +24848,7 @@
               "description": "created is greater then the parameter, created: configuration creation date",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -24989,7 +24858,7 @@
               "description": "created is greater then or equal to the parameter, created: configuration creation date",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -24999,7 +24868,7 @@
               "description": "started exactly equals to the parameter, started: configuration start date (the date when cluster was switched on this configuration first time)",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -25009,7 +24878,7 @@
               "description": "started not equals to the parameter, started: configuration start date (the date when cluster was switched on this configuration first time)",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -25019,7 +24888,7 @@
               "description": "started is less then the parameter, started: configuration start date (the date when cluster was switched on this configuration first time)",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -25029,7 +24898,7 @@
               "description": "started is less then or equal to the parameter, started: configuration start date (the date when cluster was switched on this configuration first time)",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -25039,7 +24908,7 @@
               "description": "started is greater then the parameter, started: configuration start date (the date when cluster was switched on this configuration first time)",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -25049,7 +24918,7 @@
               "description": "started is greater then or equal to the parameter, started: configuration start date (the date when cluster was switched on this configuration first time)",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -25059,7 +24928,7 @@
               "description": "finished exactly equals to the parameter, finished: configuration finish date (the date when cluster was switched from this configuration last time)",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -25069,7 +24938,7 @@
               "description": "finished not equals to the parameter, finished: configuration finish date (the date when cluster was switched from this configuration last time)",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -25079,7 +24948,7 @@
               "description": "finished is less then the parameter, finished: configuration finish date (the date when cluster was switched from this configuration last time)",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -25089,7 +24958,7 @@
               "description": "finished is less then or equal to the parameter, finished: configuration finish date (the date when cluster was switched from this configuration last time)",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -25099,7 +24968,7 @@
               "description": "finished is greater then the parameter, finished: configuration finish date (the date when cluster was switched from this configuration last time)",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -25109,7 +24978,7 @@
               "description": "finished is greater then or equal to the parameter, finished: configuration finish date (the date when cluster was switched from this configuration last time)",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -25160,6 +25029,137 @@
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "KlusterKiteNodeApi_Configuration_Sort",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "id_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "majorVersion_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "majorVersion_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "minorVersion_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "minorVersion_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "notes_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "notes_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "created_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "created_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "started_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "started_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "finished_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "finished_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "state_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "state_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isStable_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isStable_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
           "kind": "INTERFACE",
           "name": "IKlusterKiteNodeApi_Role_Connection",
           "description": "The list of connected KlusterKiteNodeApi_Role\n Security role. The amount of privileges assigned to the user",
@@ -25194,7 +25194,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -25235,7 +25235,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -25268,7 +25268,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -25323,6 +25323,16 @@
               "description": "The list of users assigned to this role",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -25333,11 +25343,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_KlusterKite_NodeManager_Client_ORM_RoleUser_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -25357,17 +25367,7 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_KlusterKite_NodeManager_Client_ORM_RoleUser_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -25387,7 +25387,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -25432,7 +25432,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -25473,7 +25473,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -25518,7 +25518,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -25542,7 +25542,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -25562,7 +25562,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -25594,6 +25594,16 @@
               "description": "The list of roles assigned to this user",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -25604,11 +25614,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_KlusterKite_NodeManager_Client_ORM_RoleUser_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -25628,17 +25638,7 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_KlusterKite_NodeManager_Client_ORM_RoleUser_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -25662,7 +25662,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -25674,7 +25674,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -25686,7 +25686,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -25730,7 +25730,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -25739,53 +25739,6 @@
               "ofType": null
             }
           ]
-        },
-        {
-          "kind": "ENUM",
-          "name": "KlusterKiteNodeApi_KlusterKite_NodeManager_Client_ORM_RoleUser_Sort",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "id_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "roleUid_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "roleUid_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "userUid_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "userUid_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
         },
         {
           "kind": "INPUT_OBJECT",
@@ -25878,7 +25831,7 @@
               "description": "roleUid exactly equals to the parameter, roleUid: the role uid",
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -25888,7 +25841,7 @@
               "description": "roleUid not equals to the parameter, roleUid: the role uid",
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -25898,7 +25851,7 @@
               "description": "userUid exactly equals to the parameter, userUid: the user uid",
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -25908,7 +25861,7 @@
               "description": "userUid not equals to the parameter, userUid: the user uid",
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -25920,32 +25873,44 @@
         },
         {
           "kind": "ENUM",
-          "name": "KlusterKiteNodeApi_Role_Sort",
+          "name": "KlusterKiteNodeApi_KlusterKite_NodeManager_Client_ORM_RoleUser_Sort",
           "description": null,
           "fields": null,
           "inputFields": null,
           "interfaces": null,
           "enumValues": [
             {
-              "name": "uid_asc",
+              "name": "id_asc",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "uid_desc",
+              "name": "id_desc",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "name_asc",
+              "name": "roleUid_asc",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "name_desc",
+              "name": "roleUid_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "userUid_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "userUid_desc",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -25984,7 +25949,7 @@
               "description": "uid exactly equals to the parameter, uid: The role uid",
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -25994,7 +25959,7 @@
               "description": "uid not equals to the parameter, uid: The role uid",
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -26101,7 +26066,7 @@
             },
             {
               "name": "name_l",
-              "description": "name lowercased equals the parameter, name: The role name",
+              "description": "name lower-cased equals the parameter, name: The role name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26111,7 +26076,7 @@
             },
             {
               "name": "name_l_not",
-              "description": "name lowercased doesn't equal the parameter, name: The role name",
+              "description": "name lower-cased doesn't equal the parameter, name: The role name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26121,7 +26086,7 @@
             },
             {
               "name": "name_l_in",
-              "description": "name lowercased is a substring of the parameter, name: The role name",
+              "description": "name lower-cased is a substring of the parameter, name: The role name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26131,7 +26096,7 @@
             },
             {
               "name": "name_l_not_in",
-              "description": "name lowercased is not a substring of the parameter, name: The role name",
+              "description": "name lower-cased is not a substring of the parameter, name: The role name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26141,7 +26106,7 @@
             },
             {
               "name": "name_l_contains",
-              "description": "name lowercased contains the parameter as substring, name: The role name",
+              "description": "name lower-cased contains the parameter as substring, name: The role name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26151,7 +26116,7 @@
             },
             {
               "name": "name_l_not_contains",
-              "description": "name lowercased doesn't contain the parameter as substring, name: The role name",
+              "description": "name lower-cased doesn't contain the parameter as substring, name: The role name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26161,7 +26126,7 @@
             },
             {
               "name": "name_l_starts_with",
-              "description": "name lowercased starts with the parameter value, name: The role name",
+              "description": "name lower-cased starts with the parameter value, name: The role name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26171,7 +26136,7 @@
             },
             {
               "name": "name_l_not_starts_with",
-              "description": "name lowercased doesn't start with the parameter value, name: The role name",
+              "description": "name lower-cased doesn't start with the parameter value, name: The role name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26181,7 +26146,7 @@
             },
             {
               "name": "name_l_ends_with",
-              "description": "name lowercased ends with the parameter value, name: The role name",
+              "description": "name lower-cased ends with the parameter value, name: The role name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26191,7 +26156,7 @@
             },
             {
               "name": "name_l_not_ends_with",
-              "description": "name lowercased doesn't end with the parameter value, name: The role name",
+              "description": "name lower-cased doesn't end with the parameter value, name: The role name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26202,6 +26167,41 @@
           ],
           "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "KlusterKiteNodeApi_Role_Sort",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "uid_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uid_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -26239,7 +26239,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -26280,7 +26280,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -26289,89 +26289,6 @@
               "ofType": null
             }
           ]
-        },
-        {
-          "kind": "ENUM",
-          "name": "KlusterKiteNodeApi_User_Sort",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "uid_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "uid_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "activeTill_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "activeTill_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "blockedTill_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "blockedTill_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "isBlocked_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "isBlocked_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "isDeleted_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "isDeleted_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "login_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "login_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
         },
         {
           "kind": "INPUT_OBJECT",
@@ -26404,7 +26321,7 @@
               "description": "uid exactly equals to the parameter, uid: The user uid",
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -26414,7 +26331,7 @@
               "description": "uid not equals to the parameter, uid: The user uid",
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -26424,7 +26341,7 @@
               "description": "activeTill exactly equals to the parameter, activeTill: A date, till which user is active. After this date the user will be blocked. Null for unlimited work.",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -26434,7 +26351,7 @@
               "description": "activeTill not equals to the parameter, activeTill: A date, till which user is active. After this date the user will be blocked. Null for unlimited work.",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -26444,7 +26361,7 @@
               "description": "activeTill is less then the parameter, activeTill: A date, till which user is active. After this date the user will be blocked. Null for unlimited work.",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -26454,7 +26371,7 @@
               "description": "activeTill is less then or equal to the parameter, activeTill: A date, till which user is active. After this date the user will be blocked. Null for unlimited work.",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -26464,7 +26381,7 @@
               "description": "activeTill is greater then the parameter, activeTill: A date, till which user is active. After this date the user will be blocked. Null for unlimited work.",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -26474,7 +26391,7 @@
               "description": "activeTill is greater then or equal to the parameter, activeTill: A date, till which user is active. After this date the user will be blocked. Null for unlimited work.",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -26484,7 +26401,7 @@
               "description": "blockedTill exactly equals to the parameter, blockedTill: A date, till which user is temporary blocked. After this date the user will be blocked. Null for unlimited work.",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -26494,7 +26411,7 @@
               "description": "blockedTill not equals to the parameter, blockedTill: A date, till which user is temporary blocked. After this date the user will be blocked. Null for unlimited work.",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -26504,7 +26421,7 @@
               "description": "blockedTill is less then the parameter, blockedTill: A date, till which user is temporary blocked. After this date the user will be blocked. Null for unlimited work.",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -26514,7 +26431,7 @@
               "description": "blockedTill is less then or equal to the parameter, blockedTill: A date, till which user is temporary blocked. After this date the user will be blocked. Null for unlimited work.",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -26524,7 +26441,7 @@
               "description": "blockedTill is greater then the parameter, blockedTill: A date, till which user is temporary blocked. After this date the user will be blocked. Null for unlimited work.",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -26534,7 +26451,7 @@
               "description": "blockedTill is greater then or equal to the parameter, blockedTill: A date, till which user is temporary blocked. After this date the user will be blocked. Null for unlimited work.",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -26681,7 +26598,7 @@
             },
             {
               "name": "login_l",
-              "description": "login lowercased equals the parameter, login: The user login",
+              "description": "login lower-cased equals the parameter, login: The user login",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26691,7 +26608,7 @@
             },
             {
               "name": "login_l_not",
-              "description": "login lowercased doesn't equal the parameter, login: The user login",
+              "description": "login lower-cased doesn't equal the parameter, login: The user login",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26701,7 +26618,7 @@
             },
             {
               "name": "login_l_in",
-              "description": "login lowercased is a substring of the parameter, login: The user login",
+              "description": "login lower-cased is a substring of the parameter, login: The user login",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26711,7 +26628,7 @@
             },
             {
               "name": "login_l_not_in",
-              "description": "login lowercased is not a substring of the parameter, login: The user login",
+              "description": "login lower-cased is not a substring of the parameter, login: The user login",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26721,7 +26638,7 @@
             },
             {
               "name": "login_l_contains",
-              "description": "login lowercased contains the parameter as substring, login: The user login",
+              "description": "login lower-cased contains the parameter as substring, login: The user login",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26731,7 +26648,7 @@
             },
             {
               "name": "login_l_not_contains",
-              "description": "login lowercased doesn't contain the parameter as substring, login: The user login",
+              "description": "login lower-cased doesn't contain the parameter as substring, login: The user login",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26741,7 +26658,7 @@
             },
             {
               "name": "login_l_starts_with",
-              "description": "login lowercased starts with the parameter value, login: The user login",
+              "description": "login lower-cased starts with the parameter value, login: The user login",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26751,7 +26668,7 @@
             },
             {
               "name": "login_l_not_starts_with",
-              "description": "login lowercased doesn't start with the parameter value, login: The user login",
+              "description": "login lower-cased doesn't start with the parameter value, login: The user login",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26761,7 +26678,7 @@
             },
             {
               "name": "login_l_ends_with",
-              "description": "login lowercased ends with the parameter value, login: The user login",
+              "description": "login lower-cased ends with the parameter value, login: The user login",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26771,7 +26688,7 @@
             },
             {
               "name": "login_l_not_ends_with",
-              "description": "login lowercased doesn't end with the parameter value, login: The user login",
+              "description": "login lower-cased doesn't end with the parameter value, login: The user login",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26782,6 +26699,89 @@
           ],
           "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "KlusterKiteNodeApi_User_Sort",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "uid_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uid_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "activeTill_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "activeTill_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "blockedTill_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "blockedTill_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isBlocked_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isBlocked_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeleted_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeleted_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "login_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "login_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -26847,7 +26847,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -26880,7 +26880,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -26892,7 +26892,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -26936,7 +26936,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -26980,6 +26980,16 @@
               "description": "The list of mutation errors",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -26990,11 +27000,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_ErrorDescription_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -27014,17 +27024,7 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_ErrorDescription_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -27044,7 +27044,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -27089,7 +27089,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -27130,7 +27130,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -27195,7 +27195,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -27204,53 +27204,6 @@
               "ofType": null
             }
           ]
-        },
-        {
-          "kind": "ENUM",
-          "name": "KlusterKiteNodeApi_ErrorDescription_Sort",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "number_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "number_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "field_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "field_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "message_asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "message_desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
         },
         {
           "kind": "INPUT_OBJECT",
@@ -27440,7 +27393,7 @@
             },
             {
               "name": "field_l",
-              "description": "field lowercased equals the parameter, field: The related field name",
+              "description": "field lower-cased equals the parameter, field: The related field name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -27450,7 +27403,7 @@
             },
             {
               "name": "field_l_not",
-              "description": "field lowercased doesn't equal the parameter, field: The related field name",
+              "description": "field lower-cased doesn't equal the parameter, field: The related field name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -27460,7 +27413,7 @@
             },
             {
               "name": "field_l_in",
-              "description": "field lowercased is a substring of the parameter, field: The related field name",
+              "description": "field lower-cased is a substring of the parameter, field: The related field name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -27470,7 +27423,7 @@
             },
             {
               "name": "field_l_not_in",
-              "description": "field lowercased is not a substring of the parameter, field: The related field name",
+              "description": "field lower-cased is not a substring of the parameter, field: The related field name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -27480,7 +27433,7 @@
             },
             {
               "name": "field_l_contains",
-              "description": "field lowercased contains the parameter as substring, field: The related field name",
+              "description": "field lower-cased contains the parameter as substring, field: The related field name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -27490,7 +27443,7 @@
             },
             {
               "name": "field_l_not_contains",
-              "description": "field lowercased doesn't contain the parameter as substring, field: The related field name",
+              "description": "field lower-cased doesn't contain the parameter as substring, field: The related field name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -27500,7 +27453,7 @@
             },
             {
               "name": "field_l_starts_with",
-              "description": "field lowercased starts with the parameter value, field: The related field name",
+              "description": "field lower-cased starts with the parameter value, field: The related field name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -27510,7 +27463,7 @@
             },
             {
               "name": "field_l_not_starts_with",
-              "description": "field lowercased doesn't start with the parameter value, field: The related field name",
+              "description": "field lower-cased doesn't start with the parameter value, field: The related field name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -27520,7 +27473,7 @@
             },
             {
               "name": "field_l_ends_with",
-              "description": "field lowercased ends with the parameter value, field: The related field name",
+              "description": "field lower-cased ends with the parameter value, field: The related field name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -27530,7 +27483,7 @@
             },
             {
               "name": "field_l_not_ends_with",
-              "description": "field lowercased doesn't end with the parameter value, field: The related field name",
+              "description": "field lower-cased doesn't end with the parameter value, field: The related field name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -27640,7 +27593,7 @@
             },
             {
               "name": "message_l",
-              "description": "message lowercased equals the parameter, message: The error message",
+              "description": "message lower-cased equals the parameter, message: The error message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -27650,7 +27603,7 @@
             },
             {
               "name": "message_l_not",
-              "description": "message lowercased doesn't equal the parameter, message: The error message",
+              "description": "message lower-cased doesn't equal the parameter, message: The error message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -27660,7 +27613,7 @@
             },
             {
               "name": "message_l_in",
-              "description": "message lowercased is a substring of the parameter, message: The error message",
+              "description": "message lower-cased is a substring of the parameter, message: The error message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -27670,7 +27623,7 @@
             },
             {
               "name": "message_l_not_in",
-              "description": "message lowercased is not a substring of the parameter, message: The error message",
+              "description": "message lower-cased is not a substring of the parameter, message: The error message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -27680,7 +27633,7 @@
             },
             {
               "name": "message_l_contains",
-              "description": "message lowercased contains the parameter as substring, message: The error message",
+              "description": "message lower-cased contains the parameter as substring, message: The error message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -27690,7 +27643,7 @@
             },
             {
               "name": "message_l_not_contains",
-              "description": "message lowercased doesn't contain the parameter as substring, message: The error message",
+              "description": "message lower-cased doesn't contain the parameter as substring, message: The error message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -27700,7 +27653,7 @@
             },
             {
               "name": "message_l_starts_with",
-              "description": "message lowercased starts with the parameter value, message: The error message",
+              "description": "message lower-cased starts with the parameter value, message: The error message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -27710,7 +27663,7 @@
             },
             {
               "name": "message_l_not_starts_with",
-              "description": "message lowercased doesn't start with the parameter value, message: The error message",
+              "description": "message lower-cased doesn't start with the parameter value, message: The error message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -27720,7 +27673,7 @@
             },
             {
               "name": "message_l_ends_with",
-              "description": "message lowercased ends with the parameter value, message: The error message",
+              "description": "message lower-cased ends with the parameter value, message: The error message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -27730,7 +27683,7 @@
             },
             {
               "name": "message_l_not_ends_with",
-              "description": "message lowercased doesn't end with the parameter value, message: The error message",
+              "description": "message lower-cased doesn't end with the parameter value, message: The error message",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -27741,6 +27694,53 @@
           ],
           "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "KlusterKiteNodeApi_ErrorDescription_Sort",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "number_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "number_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "field_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "field_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "message_asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "message_desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -27777,6 +27777,16 @@
               "description": "The list of mutation errors",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -27787,11 +27797,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_ErrorDescription_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -27811,17 +27821,7 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_ErrorDescription_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -27841,7 +27841,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -27893,7 +27893,7 @@
               "deprecationReason": null
             },
             {
-              "name": "node",
+              "name": "_node",
               "description": "The node global searcher according to Relay specification",
               "args": [
                 {
@@ -27917,7 +27917,7 @@
             }
           ],
           "inputFields": null,
-          "interfaces": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
             {
@@ -27946,7 +27946,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -28034,7 +28034,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -28045,7 +28045,7 @@
               "deprecationReason": null
             },
             {
-              "name": "node",
+              "name": "_node",
               "description": "The node global searcher according to Relay specification",
               "args": [
                 {
@@ -28072,17 +28072,17 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
               "name": "IKlusterKiteMonitoring",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
               "name": "IKlusterKiteNodeApi",
-              "ofType": null
-            },
-            {
-              "kind": "INTERFACE",
-              "name": "Node",
               "ofType": null
             }
           ],
@@ -28108,7 +28108,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -28123,12 +28123,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteMonitoring_Root",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteMonitoring_Root",
               "ofType": null
             }
           ],
@@ -28157,6 +28157,16 @@
               "description": "Gets the list of nodes",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -28167,11 +28177,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteMonitoring_Pair_System_String_Node__Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -28191,21 +28201,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteMonitoring_Pair_System_String_Node__Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -28224,6 +28224,16 @@
               "description": "Gets the  nodes flat list",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -28234,11 +28244,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteMonitoring_Node_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -28258,21 +28268,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteMonitoring_Node_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -28300,7 +28300,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -28315,12 +28315,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteMonitoring_ClusterTree",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteMonitoring_ClusterTree",
               "ofType": null
             }
           ],
@@ -28444,7 +28444,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -28459,12 +28459,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteMonitoring_Pair_System_String_Node_",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteMonitoring_Pair_System_String_Node_",
               "ofType": null
             }
           ],
@@ -28577,6 +28577,16 @@
               "description": "the actor's children",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -28587,11 +28597,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteMonitoring_Node_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -28611,21 +28621,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteMonitoring_Node_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -28665,7 +28665,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -28680,12 +28680,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteMonitoring_Node",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteMonitoring_Node",
               "ofType": null
             }
           ],
@@ -28800,6 +28800,16 @@
               "description": "The packages in the Nuget repository",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -28810,11 +28820,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_NugetPackageFamily_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -28834,21 +28844,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_NugetPackageFamily_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -28867,6 +28867,16 @@
               "description": "The list of known active nodes",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -28877,11 +28887,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Uid",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_NodeDescription_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -28901,21 +28911,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_NodeDescription_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "Guid",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -28946,6 +28946,16 @@
               "description": "the cluster migration management",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -28956,11 +28966,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_Migration_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -28980,17 +28990,7 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_Migration_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -29013,6 +29013,16 @@
               "description": "KlusterKite managing system security roles",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -29023,11 +29033,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_Configuration_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -29047,17 +29057,7 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_Configuration_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -29080,6 +29080,16 @@
               "description": "KlusterKite managing system security roles",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -29090,11 +29100,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Uid",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_Role_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -29114,21 +29124,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_Role_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "Guid",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -29147,6 +29147,16 @@
               "description": "KlusterKite managing system users",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -29157,11 +29167,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Uid",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_User_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -29181,21 +29191,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_User_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "Guid",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -29211,7 +29211,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -29226,12 +29226,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_Root",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_Root",
               "ofType": null
             }
           ],
@@ -29281,7 +29281,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -29296,12 +29296,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_ClusterManagement",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_ClusterManagement",
               "ofType": null
             }
           ],
@@ -29379,7 +29379,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -29391,7 +29391,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -29403,7 +29403,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -29450,6 +29450,16 @@
               "description": "the list of compatible node templates",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -29460,11 +29470,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_CompatibleTemplate_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -29484,17 +29494,7 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_CompatibleTemplate_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -29517,6 +29517,16 @@
               "description": "the list of compatible node templates",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -29527,11 +29537,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_CompatibleTemplate_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -29551,17 +29561,7 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_CompatibleTemplate_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -29584,6 +29584,16 @@
               "description": "the list of migration logs",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -29594,11 +29604,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_MigrationLogRecord_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -29618,17 +29628,7 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_MigrationLogRecord_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -29648,7 +29648,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -29663,12 +29663,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_Configuration",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_Configuration",
               "ofType": null
             }
           ],
@@ -29685,6 +29685,16 @@
               "description": "the list of available packages with their versions",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -29695,11 +29705,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_PackageDescription_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -29719,21 +29729,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_PackageDescription_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -29752,6 +29752,16 @@
               "description": "the list of configured node templates",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -29762,11 +29772,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_NodeTemplate_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -29786,21 +29796,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_NodeTemplate_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -29819,6 +29819,16 @@
               "description": "the list of configured cluster migrator templates",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -29829,11 +29839,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_MigratorTemplate_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -29853,21 +29863,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_MigratorTemplate_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -29911,7 +29911,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -29926,12 +29926,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_ConfigurationSettings",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_ConfigurationSettings",
               "ofType": null
             }
           ],
@@ -30055,7 +30055,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -30070,12 +30070,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_PackageDescription",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_PackageDescription",
               "ofType": null
             }
           ],
@@ -30278,6 +30278,16 @@
               "description": "The list of package requirements",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -30288,11 +30298,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_PackageRequirement_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -30312,21 +30322,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_PackageRequirement_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -30345,6 +30345,16 @@
               "description": "The list of packages to install for current template",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -30355,11 +30365,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_Pair_System_String_List_PackageDescription___Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -30379,21 +30389,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_Pair_System_String_List_PackageDescription___Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -30421,7 +30421,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -30436,12 +30436,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_NodeTemplate",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_NodeTemplate",
               "ofType": null
             }
           ],
@@ -30565,7 +30565,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -30580,12 +30580,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_PackageRequirement",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_PackageRequirement",
               "ofType": null
             }
           ],
@@ -30700,6 +30700,16 @@
               "description": "Gets a dictionary value",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -30710,11 +30720,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_PackageDescription_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -30734,21 +30744,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_PackageDescription_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -30764,7 +30764,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -30779,12 +30779,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_Pair_System_String_List_PackageDescription__",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_Pair_System_String_List_PackageDescription__",
               "ofType": null
             }
           ],
@@ -30947,6 +30947,16 @@
               "description": "The list of package requirements",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -30957,11 +30967,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_PackageRequirement_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -30981,21 +30991,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_PackageRequirement_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -31014,6 +31014,16 @@
               "description": "The list of packages to install for current template",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -31024,11 +31034,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_Pair_System_String_List_PackageDescription___Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -31048,21 +31058,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_Pair_System_String_List_PackageDescription___Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -31078,7 +31078,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -31093,12 +31093,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_MigratorTemplate",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_MigratorTemplate",
               "ofType": null
             }
           ],
@@ -31270,7 +31270,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -31285,12 +31285,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_CompatibleTemplate",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_CompatibleTemplate",
               "ofType": null
             }
           ],
@@ -31526,7 +31526,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -31538,7 +31538,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -31594,7 +31594,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -31609,12 +31609,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_MigrationLogRecord",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_MigrationLogRecord",
               "ofType": null
             }
           ],
@@ -31764,7 +31764,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -31779,12 +31779,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_ResourceState",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_ResourceState",
               "ofType": null
             }
           ],
@@ -31801,6 +31801,16 @@
               "description": "the list of migration states",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -31811,11 +31821,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_MigratorTemplateMigrationState_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -31835,21 +31845,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_MigratorTemplateMigrationState_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -31868,6 +31868,16 @@
               "description": "the list of resources that can be migrated on current stage",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -31878,11 +31888,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_ResourceMigrationState_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -31902,21 +31912,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_ResourceMigrationState_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -31932,7 +31932,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -31947,12 +31947,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_MigrationActorMigrationState",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_MigrationActorMigrationState",
               "ofType": null
             }
           ],
@@ -32103,6 +32103,16 @@
               "description": "the list of states of migrators",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -32113,11 +32123,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_MigratorMigrationState_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -32137,21 +32147,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_MigratorMigrationState_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -32167,7 +32167,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -32182,12 +32182,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_MigratorTemplateMigrationState",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_MigratorTemplateMigrationState",
               "ofType": null
             }
           ],
@@ -32326,6 +32326,16 @@
               "description": "the list of resources states",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -32336,11 +32346,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_ResourceMigrationState_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -32360,21 +32370,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_ResourceMigrationState_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -32426,7 +32426,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -32441,12 +32441,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_MigratorMigrationState",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_MigratorMigrationState",
               "ofType": null
             }
           ],
@@ -32678,7 +32678,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -32693,12 +32693,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_ResourceMigrationState",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_ResourceMigrationState",
               "ofType": null
             }
           ],
@@ -32715,6 +32715,16 @@
               "description": "the list of template states",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -32725,11 +32735,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_MigratorTemplateConfigurationState_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -32749,21 +32759,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_MigratorTemplateConfigurationState_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -32782,6 +32782,16 @@
               "description": "the list of resources that can be recovered",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -32792,11 +32802,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_ResourceConfigurationState_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -32816,21 +32826,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_ResourceConfigurationState_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -32846,7 +32846,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -32861,12 +32861,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_MigrationActorConfigurationState",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_MigrationActorConfigurationState",
               "ofType": null
             }
           ],
@@ -32993,6 +32993,16 @@
               "description": "the migrator states",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -33003,11 +33013,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_MigratorConfigurationState_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -33027,21 +33037,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_MigratorConfigurationState_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -33057,7 +33057,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -33072,12 +33072,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_MigratorTemplateConfigurationState",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_MigratorTemplateConfigurationState",
               "ofType": null
             }
           ],
@@ -33232,6 +33232,16 @@
               "description": "the state of defined resources",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -33242,11 +33252,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_ResourceConfigurationState_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -33266,21 +33276,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_ResourceConfigurationState_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -33320,7 +33320,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -33335,12 +33335,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_MigratorConfigurationState",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_MigratorConfigurationState",
               "ofType": null
             }
           ],
@@ -33524,7 +33524,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -33539,12 +33539,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_ResourceConfigurationState",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_ResourceConfigurationState",
               "ofType": null
             }
           ],
@@ -33598,7 +33598,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -33610,7 +33610,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -33620,6 +33620,16 @@
               "name": "logs",
               "description": "the list of migration logs",
               "args": [
+                {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
                 {
                   "name": "limit",
                   "description": null,
@@ -33631,11 +33641,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_MigrationLogRecord_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -33655,17 +33665,7 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_MigrationLogRecord_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -33733,7 +33733,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -33748,12 +33748,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_Migration",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_Migration",
               "ofType": null
             }
           ],
@@ -33905,7 +33905,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -33920,12 +33920,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_NugetPackageFamily",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_NugetPackageFamily",
               "ofType": null
             }
           ],
@@ -34092,6 +34092,16 @@
               "description": "the list of descriptions of installed modules",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -34102,11 +34112,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_PackageDescription_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -34126,21 +34136,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_PackageDescription_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -34172,7 +34172,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -34224,7 +34224,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Long",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -34232,7 +34232,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -34247,12 +34247,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_NodeDescription",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_NodeDescription",
               "ofType": null
             }
           ],
@@ -34326,7 +34326,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -34341,12 +34341,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_AkkaAddress",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_AkkaAddress",
               "ofType": null
             }
           ],
@@ -34363,6 +34363,16 @@
               "description": "node templates statistics data",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -34373,11 +34383,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_TemplatesStatisticsData_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -34397,21 +34407,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_TemplatesStatisticsData_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -34427,7 +34427,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -34442,12 +34442,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_TemplatesStatistics",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_TemplatesStatistics",
               "ofType": null
             }
           ],
@@ -34631,7 +34631,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -34646,12 +34646,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_TemplatesStatisticsData",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_TemplatesStatisticsData",
               "ofType": null
             }
           ],
@@ -34927,7 +34927,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -34982,6 +34982,16 @@
               "description": "The list of users assigned to this role",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -34992,11 +35002,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_KlusterKite_NodeManager_Client_ORM_RoleUser_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -35016,17 +35026,7 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_KlusterKite_NodeManager_Client_ORM_RoleUser_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -35046,7 +35046,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -35061,12 +35061,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_Role",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_Role",
               "ofType": null
             }
           ],
@@ -35182,7 +35182,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -35206,7 +35206,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -35226,7 +35226,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -35241,12 +35241,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_KlusterKite_NodeManager_Client_ORM_RoleUser",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_KlusterKite_NodeManager_Client_ORM_RoleUser",
               "ofType": null
             }
           ],
@@ -35263,6 +35263,16 @@
               "description": "The list of roles assigned to this user",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -35273,11 +35283,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_KlusterKite_NodeManager_Client_ORM_RoleUser_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -35297,17 +35307,7 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_KlusterKite_NodeManager_Client_ORM_RoleUser_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -35331,7 +35331,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -35343,7 +35343,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -35355,7 +35355,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -35399,7 +35399,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -35414,12 +35414,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_User",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_User",
               "ofType": null
             }
           ],
@@ -35563,7 +35563,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -35578,12 +35578,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_CurrentUserApi",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_CurrentUserApi",
               "ofType": null
             }
           ],
@@ -35601,7 +35601,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -35613,7 +35613,7 @@
               "args": [],
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -35657,7 +35657,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -35672,12 +35672,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_KlusterKiteUserDescription",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_KlusterKiteUserDescription",
               "ofType": null
             }
           ],
@@ -36407,6 +36407,16 @@
               "description": "The list of mutation errors",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -36417,11 +36427,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_ErrorDescription_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -36441,17 +36451,7 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_ErrorDescription_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -36471,7 +36471,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -36486,12 +36486,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_MutationResult_System_Boolean_",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_MutationResult_System_Boolean_",
               "ofType": null
             }
           ],
@@ -36627,7 +36627,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -36642,12 +36642,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_ErrorDescription",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_ErrorDescription",
               "ofType": null
             }
           ],
@@ -37472,7 +37472,7 @@
               "description": "the operation execution start time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -37482,7 +37482,7 @@
               "description": "the operation execution finish time",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -37698,7 +37698,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -37708,7 +37708,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -37739,7 +37739,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -37749,7 +37749,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -37811,7 +37811,7 @@
               "description": "The role uid",
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -37870,7 +37870,7 @@
               "description": "The object's id",
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -37994,7 +37994,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -38035,7 +38035,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -38045,7 +38045,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -38076,7 +38076,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -38086,7 +38086,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -38148,7 +38148,7 @@
               "description": "The user uid",
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -38158,7 +38158,7 @@
               "description": "A date, till which user is active. After this date the user will be blocked. Null for unlimited work.",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -38168,7 +38168,7 @@
               "description": "A date, till which user is temporary blocked. After this date the user will be blocked. Null for unlimited work.",
               "type": {
                 "kind": "SCALAR",
-                "name": "Date",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
@@ -38219,7 +38219,7 @@
               "description": "The object's id",
               "type": {
                 "kind": "SCALAR",
-                "name": "Uid",
+                "name": "Guid",
                 "ofType": null
               },
               "defaultValue": null
@@ -38360,6 +38360,16 @@
               "description": "The list of mutation errors",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {
@@ -38370,11 +38380,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "id",
+                  "name": "filter",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
+                    "kind": "INPUT_OBJECT",
+                    "name": "KlusterKiteNodeApi_ErrorDescription_Filter_Input",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -38394,17 +38404,7 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "filter",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "KlusterKiteNodeApi_ErrorDescription_Filter_Input",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "offset",
+                  "name": "id",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -38424,7 +38424,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The node id",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -38439,12 +38439,12 @@
           "interfaces": [
             {
               "kind": "INTERFACE",
-              "name": "IKlusterKiteNodeApi_MutationResult_Migration_",
+              "name": "Node",
               "ofType": null
             },
             {
               "kind": "INTERFACE",
-              "name": "Node",
+              "name": "IKlusterKiteNodeApi_MutationResult_Migration_",
               "ofType": null
             }
           ],

--- a/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/ConfigCopyPage/ConfigurationConfigCopyPage.js
+++ b/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/ConfigCopyPage/ConfigurationConfigCopyPage.js
@@ -224,7 +224,7 @@ export default Relay.createContainer(
               }
             }
           }
-          configuration: node(id: $configurationId) @include( if: $nodeExists ) {
+          configuration: _node(id: $configurationId) @include( if: $nodeExists ) {
             ...on IKlusterKiteNodeApi_Configuration {
               _id
               name

--- a/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/ConfigurationPage/ConfigurationPage.js
+++ b/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/ConfigurationPage/ConfigurationPage.js
@@ -234,7 +234,7 @@ export default Relay.createContainer(
       api: () => Relay.QL`
         fragment on IKlusterKiteNodeApi {
           id
-          configuration: node(id: $id) @include( if: $nodeExists ) {
+          configuration: _node(id: $id) @include( if: $nodeExists ) {
             ...on IKlusterKiteNodeApi_Configuration {
               _id
               name

--- a/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/FeedPage/FeedPage.js
+++ b/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/FeedPage/FeedPage.js
@@ -108,7 +108,7 @@ export default Relay.createContainer(
         fragment on IKlusterKiteNodeApi {
           __typename
           id
-          configuration:node(id: $configurationId) {
+          configuration: _node(id: $configurationId) {
             ...on IKlusterKiteNodeApi_Configuration {
               _id
               settings {

--- a/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/MigratorTemplatePage/TemplatePage.js
+++ b/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/MigratorTemplatePage/TemplatePage.js
@@ -165,7 +165,7 @@ export default Relay.createContainer(
               }
             }
           }
-          configuration:node(id: $configurationId) {
+          configuration: _node(id: $configurationId) {
             ...on IKlusterKiteNodeApi_Configuration {
               _id
               settings   {
@@ -173,7 +173,7 @@ export default Relay.createContainer(
               }
             }
           }
-          template:node(id: $id) @include( if: $nodeExists ) {
+          template: _node(id: $id) @include( if: $nodeExists ) {
             ...on IKlusterKiteNodeApi_MigratorTemplate {
               id
               code

--- a/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/NodeTemplatePage/TemplatePage.js
+++ b/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/NodeTemplatePage/TemplatePage.js
@@ -165,7 +165,7 @@ export default Relay.createContainer(
               }
             }
           }
-          configuration:node(id: $configurationId) {
+          configuration: _node(id: $configurationId) {
             ...on IKlusterKiteNodeApi_Configuration {
               _id
               settings {
@@ -173,7 +173,7 @@ export default Relay.createContainer(
               }
             }
           }
-          template:node(id: $id) @include( if: $nodeExists ) {
+          template: _node(id: $id) @include( if: $nodeExists ) {
             ...on IKlusterKiteNodeApi_NodeTemplate {
               id
               code

--- a/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/PackagePage/PackagePage.js
+++ b/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/PackagePage/PackagePage.js
@@ -123,7 +123,7 @@ export default Relay.createContainer(
               }
             }
           }
-          configuration:node(id: $configurationId) {
+          configuration: _node(id: $configurationId) {
             ...on IKlusterKiteNodeApi_Configuration {
               _id
               settings {
@@ -132,7 +132,7 @@ export default Relay.createContainer(
               }
             }
           }
-          package:node(id: $id) @include( if: $nodeExists ) {
+          package: _node(id: $id) @include( if: $nodeExists ) {
             ...on IKlusterKiteNodeApi_PackageDescription {
               id
               version

--- a/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/PackagesPage/PackagesPage.js
+++ b/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/PackagesPage/PackagesPage.js
@@ -120,7 +120,7 @@ export default Relay.createContainer(
               }
             }
           }
-          configuration:node(id: $configurationId) {
+          configuration: _node(id: $configurationId) {
             ...on IKlusterKiteNodeApi_Configuration {
               _id
               settings {

--- a/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/RolePage/RolePage.js
+++ b/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/RolePage/RolePage.js
@@ -165,7 +165,7 @@ export default Relay.createContainer(
       api: () => Relay.QL`
         fragment on IKlusterKiteNodeApi {
           id
-          role: node(id: $id) @include( if: $nodeExists ) {
+          role: _node(id: $id) @include( if: $nodeExists ) {
             ...on IKlusterKiteNodeApi_Role {
               id
               uid

--- a/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/SeedPage/SeedPage.js
+++ b/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/SeedPage/SeedPage.js
@@ -111,7 +111,7 @@ export default Relay.createContainer(
         fragment on IKlusterKiteNodeApi {
           __typename
           id
-          configuration:node(id: $configurationId) {
+          configuration: _node(id: $configurationId) {
             ...on IKlusterKiteNodeApi_Configuration {
               _id
               settings {

--- a/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/UserPage/ResetPasswordPage.js
+++ b/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/UserPage/ResetPasswordPage.js
@@ -106,7 +106,7 @@ export default Relay.createContainer(
       api: () => Relay.QL`
         fragment on IKlusterKiteNodeApi {
           id
-          user: node(id: $id) @include( if: $nodeExists ) {
+          user: _node(id: $id) @include( if: $nodeExists ) {
             ...on IKlusterKiteNodeApi_User {
               id
               uid

--- a/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/UserPage/UserPage.js
+++ b/Docker/KlusterKiteMonitoring/klusterkite-web/src/containers/UserPage/UserPage.js
@@ -351,7 +351,7 @@ export default Relay.createContainer(
       api: () => Relay.QL`
         fragment on IKlusterKiteNodeApi {
           id
-          user: node(id: $id) @include( if: $nodeExists ) {
+          user: _node(id: $id) @include( if: $nodeExists ) {
             ...on IKlusterKiteNodeApi_User {
               id
               uid

--- a/KlusterKite.API/KlusterKite.API.Provider/Resolvers/EnumResolver.cs
+++ b/KlusterKite.API/KlusterKite.API.Provider/Resolvers/EnumResolver.cs
@@ -71,6 +71,18 @@ namespace KlusterKite.API.Provider.Resolvers
         /// <inheritdoc />
         public Task<JToken> ResolveQuery(object source, ApiRequest request, ApiField apiField, RequestContext context, JsonSerializer argumentsSerializer, Action<Exception> onErrorCallback)
         {
+            // A nullable enum (e.g. EnMigrationSteps?) can legitimately be
+            // null when no migration is in progress. Without this guard
+            // source.ToString() throws NullReferenceException, which the
+            // GraphQL pipeline then surfaces as
+            //   "Error trying to resolve field '<name>'. INVALID_OPERATION".
+            // Return raw null (not JValue.CreateNull); GraphQL.NET 7.x's
+            // EnumerationGraphType coercion rejects a wrapped JValue-null.
+            if (source == null)
+            {
+                return Task.FromResult<JToken>(null);
+            }
+
             var value = hasFlags ? new JValue((long)source) : new JValue(source.ToString());
             return Task.FromResult<JToken>(value);
         }

--- a/KlusterKite.NodeManager/KlusterKite.NodeManager.Launcher.Utils/PackageUtils.cs
+++ b/KlusterKite.NodeManager/KlusterKite.NodeManager.Launcher.Utils/PackageUtils.cs
@@ -228,44 +228,54 @@ namespace KlusterKite.NodeManager.Launcher.Utils
         /// </returns>
         public static async Task<IPackageSearchMetadata> Search(string nugetUrl, string id, NuGetVersion version)
         {
-            var source = new PackageSource(nugetUrl) { AllowInsecureConnections = true };
-            var sourceRepository = Repository.Factory.GetCoreV3(source);
-            var resource = await sourceRepository.GetResourceAsync<PackageSearchResource>().ConfigureAwait(false);
-            var result = new List<IPackageSearchMetadata>();
-
-            const int PageSize = 1000;
-            var position = 0;
-            while (true)
-            {
-                var searchMetadata = (await resource.SearchAsync(
-                                         id,
-                                         new SearchFilter(true, null),
-                                         position,
-                                         PageSize,
-                                         NullLogger.Instance,
-                                         CancellationToken.None)).ToList();
-                var previousCount = result.Count;
-                result.AddRange(searchMetadata);
-                position += PageSize;
-                if (searchMetadata.Any(s => s.Identity.Id == id))
-                {
-                    break;
-                }
-
-                if (result.Count - previousCount < PageSize)
-                {
-                    break;
-                }
-            }
-
-            var package = result.FirstOrDefault(s => s.Identity.Id == id);
-            if (package == null)
+            // Same V2-direct path as GetByIdAsync, but filter by exact version
+            // instead of picking the latest. The NuGet client's
+            // PackageSearchResource is unreliable against the local
+            // simple-nuget-server (its V2 service-index probe fails with
+            // "Unable to load the service index for source ...").
+            var baseUrl = nugetUrl.TrimEnd('/');
+            var url = $"{baseUrl}/FindPackagesById()?id='{Uri.EscapeDataString(id)}'";
+            var response = await HttpClient.GetAsync(url).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
             {
                 return null;
             }
 
-            var versions = (await package.GetVersionsAsync()).ToList();
-            return versions.FirstOrDefault(v => v.Version == version)?.PackageSearchMetadata;
+            var xml = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var doc = XDocument.Parse(xml);
+            XNamespace d = "http://schemas.microsoft.com/ado/2007/08/dataservices";
+            XNamespace m = "http://schemas.microsoft.com/ado/2007/08/dataservices/metadata";
+            XNamespace atom = "http://www.w3.org/2005/Atom";
+
+            var entry = doc.Descendants(atom + "entry")
+                .Select(e => new
+                {
+                    e,
+                    v = NuGetVersion.TryParse(
+                            e.Element(m + "properties")?.Element(d + "NormalizedVersion")?.Value
+                            ?? e.Element(m + "properties")?.Element(d + "Version")?.Value
+                            ?? string.Empty,
+                            out var ver)
+                        ? ver
+                        : null
+                })
+                .FirstOrDefault(x => x.v != null && x.v == version)?.e;
+            if (entry == null)
+            {
+                return null;
+            }
+
+            var props = entry.Element(m + "properties");
+            if (props == null)
+            {
+                return null;
+            }
+
+            var packageId = props.Element(d + "Id")?.Value ?? entry.Element(atom + "title")?.Value ?? id;
+            var dependencyStr = props.Element(d + "Dependencies")?.Value ?? string.Empty;
+            var dependencySets = ParseV2DependencyString(dependencyStr);
+
+            return new V2DirectMetadata(new PackageIdentity(packageId, version), dependencySets);
         }
 
         /// <summary>

--- a/KlusterKite.Web/KlusterKite.Web.GraphQL.Publisher/Internals/MergedApiRoot.cs
+++ b/KlusterKite.Web/KlusterKite.Web.GraphQL.Publisher/Internals/MergedApiRoot.cs
@@ -149,7 +149,13 @@ namespace KlusterKite.Web.GraphQL.Publisher.Internals
         private FieldType CreateNodeField(NodeInterface nodeInterface, bool addResolver)
         {
             var nodeFieldType = new FieldType();
-            nodeFieldType.Name = "node";
+            // Per Relay spec, a field named exactly "node" with (id: ID): Node
+            // signature is reserved for the root Query type only. Defining the
+            // same field name on an API sub-root makes Relay's compiler refuse
+            // to transform any fragment that selects it. Use "_node" here so
+            // it is still distinguishable in the schema but doesn't trip
+            // Relay's check.
+            nodeFieldType.Name = "_node";
             nodeFieldType.ResolvedType = nodeInterface;
             nodeFieldType.Description = "The node global searcher according to Relay specification";
             nodeFieldType.Arguments =

--- a/KlusterKite.Web/KlusterKite.Web.GraphQL.Publisher/Internals/MergedEnumType.cs
+++ b/KlusterKite.Web/KlusterKite.Web.GraphQL.Publisher/Internals/MergedEnumType.cs
@@ -10,11 +10,15 @@
 namespace KlusterKite.Web.GraphQL.Publisher.Internals
 {
     using System.Collections.Generic;
+    using System.Threading.Tasks;
 
+    using global::GraphQL;
     using global::GraphQL.Types;
 
     using KlusterKite.API.Client;
     using KlusterKite.Web.GraphQL.Publisher.GraphTypes;
+
+    using Newtonsoft.Json.Linq;
 
     /// <summary>
     /// The merged type representing some enum value
@@ -71,6 +75,24 @@ namespace KlusterKite.Web.GraphQL.Publisher.Internals
             }
 
             return this.ComplexTypeName;
+        }
+
+        /// <inheritdoc />
+        public override async ValueTask<object> ResolveAsync(IResolveFieldContext context)
+        {
+            // Provider serializes null enum properties as JValue.CreateNull
+            // (a non-null JToken whose .Value is null). Returning that JToken
+            // to GraphQL.NET's EnumerationGraphType.Serialize lets it stringify
+            // as "" and then fail "Error trying to resolve field '<name>'."
+            // INVALID_OPERATION. Unwrap to a real null so the framework treats
+            // the field as nullable-with-no-value and emits null.
+            var result = await base.ResolveAsync(context);
+            if (result is JValue jv && jv.Value == null)
+            {
+                return null;
+            }
+
+            return result;
         }
 
         /// <inheritdoc />

--- a/nuget.config
+++ b/nuget.config
@@ -5,7 +5,6 @@
   </config>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="local" value="http://localhost:81" allowInsecureConnections="true" />
   </packageSources>
   <disabledPackageSources />
 </configuration>


### PR DESCRIPTION
Five backend fixes around the GraphQL layer that surfaced when the monitoring UI started exercising every page.

## 1. Per-API \`node(id)\` collides with Relay's reserved root \`node(id)\` (\`fa8bf46c\`)
Relay 0.x's compiler treats any field named exactly \`node\` with a \`(id: ID): Node\` signature as the global node-searcher and refuses to let it appear anywhere except the root Query type. The schema rename in \`638fa784\` (\`__node\` → \`node\`, to satisfy the GraphQL spec) collided with that rule on every API sub-root: any Relay fragment selecting e.g. \`IKlusterKiteNodeApi.node(id: \$id)\` failed to transform with "Relay requires the node field to be defined on the root type."

Result: opening any of the configuration / package / role / user edit pages crashed in the browser console with a Relay transform error.

Rename \`MergedApiRoot.CreateNodeField\`'s field name to \`_node\` (single leading underscore is GraphQL-spec compliant; only double-underscore is reserved). Update all 14 React Relay queries that selected \`<alias>: node(id: \$foo)\` to \`<alias>: _node(id: \$foo)\`. The root-level \`node\` in \`MergedRoot\` is left untouched: that's the one Relay actually wants on the schema root.

## 2. schema.json regenerated to match (\`ede2fff3\`)
Refresh the introspection snapshot from a running cluster so the babel-relay-plugin (which validates every \`Relay.QL\` fragment against this file at React build time) sees the renamed \`_node(id)\` field.

## 3. \`PackageUtils.Search(url, id, version)\` bypasses the NuGet client (\`4b6aa174\`)
The earlier .NET 9 fix in \`638fa784\` ("Replace PackageSearchResource…") rewrote \`GetByIdAsync\` to hit the V2 \`FindPackagesById\` endpoint over raw HTTP, but only that one method. \`Search(url, id, version)\` — used by \`RemotePackageRepository.GetAsync(id, version)\` and reachable from the ConfigurationCheckActor's "Check configuration" UI button — still went through \`Repository.Factory.GetCoreV3\` + \`PackageSearchResource\`. That discovery path fails against the local simple-nuget-server with "Unable to load the service index for source http://nuget/", so any "Update all packages to latest" + "Check configuration" round trip on a draft configuration crashes.

Port the same \`FindPackagesById\` + V2 atom-XML parsing to \`Search()\`, just filtering the entries by exact version instead of picking the latest. Also drops the manual paging loop, which only existed to work around the NuGet client returning the wrong package on text searches for IDs like \`StackExchange.Redis\`.

## 4 + 5. Nullable enum fields (\`e4a29c76\`, \`e5895aa5\`)
Two ways the same null-enum bug surfaced.

- **\`EnumResolver<T>.ResolveQuery\`** called \`source.ToString()\` directly. When the resolved field value is null (e.g. \`ResourceState.CurrentMigrationStep\` of type \`EnMigrationSteps?\` outside an active migration), it threw NullReferenceException; the GraphQL pipeline surfaced the failure as "Error trying to resolve field '<name>'." with extension code INVALID_OPERATION, even though the field is declared nullable in the schema.

- **\`MergedEnumType\` on the publisher side**: the provider serializes a null enum property as \`JValue.CreateNull()\` inside the JObject result. The default \`ResolveAsync\` (in \`MergedType.cs\`) hands that JToken back to GraphQL.NET, which then routes it through \`EnumerationGraphType.Serialize\`. GraphQL.NET 7.x's enum serializer doesn't recognize a JValue whose underlying value is null — it tries to look it up by stringified name, finds no match, and surfaces the same "Error trying to resolve field" error. The error fires after the data path has already filled the field with null, so the response carries both \`data.<field>: null\` and an \`errors[]\` entry, breaking any client (Relay) that aborts on errors.

Add null guards in both resolvers.

Hit on the Migration page for \`ResourceState.currentMigrationStep\` whenever no migration is in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)