### PR TITLE
Add LocalDevClusterUpdate Cake target for one-shot devcluster upgrade

### DIFF
--- a/.claude/skills/cluster-upgrade/SKILL.md
+++ b/.claude/skills/cluster-upgrade/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: cluster-upgrade
+description: Use when refreshing a running KlusterKite local devcluster after code/HOCON/Docker-image changes. Idiomatic flow is one Cake target — `LocalDevClusterUpdate` — that bumps the patch, pushes new packages, clones the Active configuration, and migrates the cluster end-to-end. Skill points at the target and documents the narrow cases where you'd take a different path.
+---
+
+KlusterKite was designed to upgrade in place via configuration migrations, not by replacing running containers. Each cluster Configuration pins a set of `PackageRequirements` and the resolved `PackagesToInstall` per template. To roll new code:
+
+1. **Bump versions** so old and new packages can coexist on the feed.
+2. **Build and push** to the local NuGet feed.
+3. **Create a new Configuration** that picks up the new versions and migrate the cluster to it.
+
+Containers stay running throughout. Migration handles draining, re-launching, and rolls back on failure.
+
+## 1. Idiomatic upgrade — `LocalDevClusterUpdate`
+
+Run the one composite target. It is fully deterministic; no operator approvals between steps.
+
+```bash
+NUGET_API_KEY=KlusterKite NUGET_SERVER_URL=http://localhost:28081 \
+  dotnet cake build.cake --target=LocalDevClusterUpdate --notes="..."
+```
+
+What it does:
+
+1. `FinalPushLocalPackages` — auto-bumps the patch (`0.0.5-local` → `0.0.6-local`), builds Release, packs, pushes everything to the local NuGet feed.
+2. Authenticates against `/api/1.x/security/token` (defaults to `admin/admin` against `KlusterKite.NodeManager.WebApplication`).
+3. Reads the Active Configuration, queries `nugetPackages` for the latest versions on the feed, and clones the Active settings into a new Draft with the version bumped (`--bump=minor` by default; pass `major` or `none`) and the `packages` list refreshed.
+4. `configurations_check` → `setReady` → `migrationCreate`.
+5. Walks the migration: per-template forward `migrationResourceUpdate` calls, `migrationNodesUpdate(Destination)`, manual `upgradeNode` for any min-instance pinned templates the cluster won't auto-cycle (the same restart the home page's per-node Reset button calls), then `migrationFinish`.
+6. Verifies `currentMigration` cleared, the new Configuration is Active, the previous one is Archived, and zero `isObsolete: true` nodes remain.
+
+If any step fails, the target throws — the Cake exit code tells you the cluster's state didn't reach the target. The cluster is left where it stopped (typically with a Draft you can inspect or delete and a `currentMigration` either rolled back or cancellable via the API).
+
+### Arguments
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--notes` | `""` | The Configuration's audit trail. Empty is allowed for human iteration; **agents should always pass meaningful notes** describing what's actually changing (package version delta, bug fixed, issue/PR number). |
+| `--name` | `Release YYYYMMDDHHMMSS` (UTC) | Human label shown in the Configurations list. |
+| `--bump` | `minor` | `major` resets minor to 0; `none` keeps versions (rarely useful). The package patch is independent — that always bumps via `SetVersion`. |
+| `--api` | `http://localhost:28080` (env: `KK_API_URL`) | Cluster's external HTTP endpoint. |
+| `--user` / `--password` / `--client-id` | `admin` / `admin` / `KlusterKite.NodeManager.WebApplication` (env: `KK_USER`, `KK_PASSWORD`, `KK_CLIENT_ID`) | Auth. |
+| `--timeout` | `900` | Seconds for any single phase (resource update, node update, migration finish). |
+
+### Notes on `--notes`
+
+The Configuration's notes field is the only human-readable audit trail of what changed in each migration — surfaced in the Configurations list and on the Configuration page. Useful examples:
+
+- `"Akka 1.5.67 → 1.5.68; refresh after PackageUtils.Search null fix"`
+- `"#issue-42: ConfigurationCheckActor INVALID_OPERATION on null enum"`
+- `"GraphQL.Publisher 0.1.3-local; rolls back PR #26 hotfix that broke MigrationSteps"`
+
+Useless examples (don't ship as an agent): `"update"`, `"bump"`, `""`, `"."`.
+
+### When to also rebuild Docker images
+
+If your change includes the **launcher binary** (anything under `KlusterKite.NodeManager.Launcher.*` or `KlusterKite.NodeManager.Seeder.Launcher`) or any HOCON copied into a Docker image (`Docker/KlusterKite*/seeder.hocon`, `Docker/KlusterKite*/start-publisher.hocon`, etc.), `LocalDevClusterUpdate` is not enough — those binaries live in the image, not in NuGet packages. Run the image build first, then the target:
+
+```bash
+dotnet cake build.cake --target=FinalBuildDocker
+NUGET_API_KEY=KlusterKite NUGET_SERVER_URL=http://localhost:28081 \
+  dotnet cake build.cake --target=LocalDevClusterUpdate --notes="..."
+```
+
+## 2. Cold start (no Active configuration yet)
+
+Different problem from upgrade. On first boot of a fresh devcluster:
+
+1. `nuget` (image) starts empty.
+2. `seeder` waits for `RequiredPackages` to appear on NuGet (retry loop in seeder.launcher).
+3. `dotnet cake build.cake --target=FinalPushLocalPackages` populates the feed.
+4. Seeder resolves `PackageRequirements` → writes Initial Configuration to the DB and fallback JSON files to `/fallback/`.
+5. `manager`, `worker`, `publisher*` start, fetch their NodeStartUpConfiguration from the API (or the fallback JSON if the API is unreachable), download packages, exec `KlusterKite.Core.Service`.
+
+After PR #20 the seeder is a hard blocker: any package resolution error throws and the launcher retries until the feed catches up. The seeder also re-resolves Active and Ready configurations against the current NuGet feed on every run, so a cold restart against newer packages converges automatically.
+
+## 3. Debug-only shortcut: skip versioning, force-replace `0.0.0-local`
+
+When iterating on one package without wanting to bump versions, you can overwrite `0.0.0-local` directly. **This is not an upgrade** — it bypasses the migration mechanism, doesn't run `ConfigurationCheckActor`, and leaves the DB-stored `PackagesToInstall` referring to whatever versions the live nodes happen to have downloaded.
+
+Only use it when:
+- The package's published version is still `0.0.0-local` (default outside CI),
+- You're sure no other `PackagesToInstall` row in any Configuration references the changed package's transitive surface,
+- You'll verify behavior immediately and not leave the cluster in this state.
+
+```bash
+# 1. Build (no SetVersion, so version stays at 0.0.0-local)
+NUGET_API_KEY=KlusterKite NUGET_SERVER_URL=http://localhost:28081 \
+  dotnet cake build.cake --target=Nuget
+
+# 2. simple-nuget-server returns 409 on duplicate version. Wipe row + file.
+PKG_ID=KlusterKite.API.Provider                  # ← only the changed package(s)
+docker exec klusterkite-nuget-1 python -c "
+import sqlite3
+c=sqlite3.connect('/var/www/db/packages.sqlite3')
+c.execute('delete from versions where PackageId = ?', ('$PKG_ID',))
+c.execute('delete from packages where PackageId = ?', ('$PKG_ID',))
+c.commit()"
+docker exec klusterkite-nuget-1 sh -c "rm -rf /var/www/packagefiles/$PKG_ID"
+dotnet nuget push temp/packageOut/$PKG_ID.0.0.0-local.nupkg \
+  --source http://localhost:28081 --api-key KlusterKite \
+  --allow-insecure-connections
+
+# 3. Recreate consumers so they re-download.
+#    manager + worker run providers; publishers run GraphQL.Publisher; seeder runs the seed dll.
+cd Docker/KlusterKite
+docker compose -p klusterkite up -d --force-recreate <services...>
+```
+
+The recreate cascades to `seeder` (`service_completed_successfully` dep). After PR #20 the seeder will refresh Active and Ready configs against the new NuGet state, which keeps things consistent — but that's a safety net, not the upgrade path.
+
+## 4. Decision quick-reference
+
+| Change | Path |
+|---|---|
+| Code in any package | §1 — `dotnet cake build.cake --target=LocalDevClusterUpdate --notes="..."` |
+| One package, debugging an iteration | §3 — overwrite `0.0.0-local` and recreate consumers |
+| Fresh checkout, no Active config | §2 — cold start (push packages, let seeder run) |
+| Launcher binary (`KlusterKite.NodeManager.Launcher.*`) | `cake FinalBuildDocker`, then §1 |
+| HOCON inside `KlusterKite.NodeManager/Resources/akka.hocon` | Same as code change to that package |
+| HOCON copied into a Docker image (`Docker/KlusterKite*/seeder.hocon`) | `docker buildx build` of that dir, recreate that container |
+| `docker-compose.yml` | `docker compose up -d --force-recreate <svc>`, no build |
+| React app | `npm run build` in `klusterkite-web` → image build → recreate `monitoringUI` |
+
+## 5. Driving the API by hand (rare)
+
+Most of the time you should not need this — `LocalDevClusterUpdate` covers the full happy path. Reach for it only when:
+- Diagnosing why the target failed mid-migration and you want to inspect the live state.
+- Cancelling a stuck migration that the target left behind (its Cake exit doesn't auto-cancel).
+- Custom flows the target doesn't support (rolling forward only some templates, switching back to a Source state, etc.).
+
+Auth, then fire any of:
+
+```bash
+TOKEN=$(curl -s -X POST -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'grant_type=password&username=admin&password=admin&client_id=KlusterKite.NodeManager.WebApplication' \
+  http://localhost:28080/api/1.x/security/token | python -c "import json,sys; print(json.load(sys.stdin)['access_token'])")
+
+# Inspect state
+curl -s -X POST -H 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" \
+  -d '{"query":"{api{klusterKiteNodesApi{
+        clusterManagement{currentMigration{state}}
+        configurations(sort:[id_desc],limit:3){edges{node{_id name state}}}
+        getActiveNodeDescriptions{edges{node{isObsolete nodeTemplate}}}
+      }}}"}' \
+  http://localhost:28080/api/1.x/graphQL | python -m json.tool
+
+# Cancel an in-flight migration
+curl -s -X POST -H 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" \
+  -d '{"query":"mutation{ klusterKiteNodeApi_klusterKiteNodesApi_clusterManagement_migrationCancel(input:{clientMutationId:\"x\"}){ result } }"}' \
+  http://localhost:28080/api/1.x/graphQL
+```
+
+Mutation reference (the same surface `LocalDevClusterUpdate` uses internally):
+
+| Step | Mutation | Payload type |
+|---|---|---|
+| Create draft | `..._configurations_create(input:{newNode:{majorVersion,minorVersion,name,notes}})` | `Configuration_NodeMutationPayload` (selects `node{_id} errors{edges{node{field message}}}`) |
+| Write settings | `..._configurations_update(input:{id, newNode:{id,settings:{...}}})` | same |
+| Validate | `..._configurations_check(input:{id})` | same |
+| Draft → Ready | `..._configurations_setReady(input:{id})` | same |
+| Start migration | `..._clusterManagement_migrationCreate(input:{newConfigurationId})` | `MutationResult_Migration__MutationPayload` (errors live under inner `result{errors{...}}`) |
+| Migrate resources | `..._clusterManagement_migrationResourceUpdate(input:{request:{resources:[...]}})` | `Boolean_MutationPayload` (just `result`) |
+| Migrate nodes | `..._clusterManagement_migrationNodesUpdate(input:{target:Destination})` | same |
+| Restart a node | `..._upgradeNode(input:{address:"akka.tcp://..."})` | `MutationResult_System_Boolean__MutationPayload` (`result{result}`) |
+| Finish | `..._clusterManagement_migrationFinish(input:{})` | `Boolean_MutationPayload` |
+| Cancel | `..._clusterManagement_migrationCancel(input:{})` | same |
+
+Two GraphQL ↔ JSON quirks worth knowing:
+
+- **Output schema renames `id` → `_id`** on all sub-API types (Relay collision; PR #19 fix). The **input** types still use plain `id`. So when you query a configuration's packages you get `{_id, version}`, but you must send `{id, version}` back via `configurations_update`.
+- **Send settings via GraphQL variables, not inline literals.** The resolver coerces variables fine but rejects inline literals like `priority:1.0` (Float → non-nullable `double`) and `forceUpdate:false` (Bool → non-nullable `bool`) with a generic `ARGUMENT` error. `LocalDevClusterUpdate` always passes settings as a typed variable.
+
+## 6. Pitfalls
+
+### Migration stuck in `Preparing`
+The chosen target Configuration's `PackagesToInstall` doesn't have the runtime's framework key (`.NETCoreApp,Version=v9.0`). Causes: it was Check'd against an old `SupportedFrameworks` list (pre-PR #20), or `MigrationActor` can't extract the migrator template service.
+
+`LocalDevClusterUpdate` always runs `configurations_check` against the live cluster (so the framework keys match what `MigrationActor` will look up) before `setReady`. If you took the manual path and the configuration was Check'd before PR #20, cancel the migration and re-run the target — it'll create a fresh Draft.
+
+### `seed` container exits, `manager` grabs `172.18.0.6`
+The cluster seed image's process can exit cleanly post-bootstrap. Its reserved IP is freed, and a recreated `manager` (no fixed IP) can take it. Subsequent `up -d seed` then fails with "Address already in use".
+
+```bash
+docker stop klusterkite-manager-1
+docker compose -p klusterkite up -d seed
+docker compose -p klusterkite up -d manager
+```
+
+`LocalDevClusterUpdate` does not auto-recover from a missing `seed` — without it the cluster can't form, all GraphQL calls return 503, and the target will throw on the first auth attempt. Bring `seed` back first, then re-run.
+
+### nuget container nginx doesn't bind on cold start
+`klusterkite-nuget-1` runs hhvm + nginx via supervisord. Nginx fails to bind `:80` on first start; `ss -tln` inside shows only `:9000`. A reload fixes it:
+
+```bash
+docker exec klusterkite-nuget-1 nginx -s reload
+```
+
+Symptom: seeder logs `Connection refused (nuget:80)` in retry loop.
+
+### Package wipe partially succeeded
+If you wiped the `versions` row but not `/var/www/packagefiles/<pkg>/<ver>.nupkg` (or vice versa), the next push 409s and the search index gets out of sync. Always do BOTH steps in §3.
+
+### MonitoringUI shows stale UI after rebuild
+Browser caches the bundled JS. Hard-reload (Ctrl/Cmd-Shift-R). The bundled JS filename hash changes per build; cached URLs return 404 after a refresh — that's the signal the new bundle is live.
+
+### Two clusters fighting for ports / IPs
+The `forge-*` cluster and `klusterkite-*` share `klusterkite/*:latest` images but use different Docker networks (172.18.x vs 172.19.x) and different host ports via `Docker/KlusterKite/.env` (80→28080 / 81→28081 / 82→28082 / 9200→28200 / 5601→28601 / 1194→28194). `docker compose down` in one project doesn't kill the other. Rebuilding `klusterkite/*:latest` doesn't affect already-running containers — they hold their pinned image ID until recreate.
+
+### `dotnet nuget push` rejects HTTP
+PR #17 added `--allow-insecure-connections` to every Cake push site. If you're pushing manually outside of Cake, include the flag.

--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,8 @@
 
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json.Nodes;
+
 // Configuration
 var testPackageName = "KlusterKite.Core";
 var rootDir = MakeAbsolute(Directory("./")).FullPath;
@@ -1124,6 +1128,674 @@ Task("FinalBuildDocker")
     Information("Finalizing the build of all Docker images...");
 
     Information("All Docker images have been built and cleaned successfully.");
+});
+
+// =============================================================================
+// LocalDevClusterUpdate
+// =============================================================================
+// One-shot path for refreshing a running local devcluster after code/HOCON/
+// Docker-image changes:
+//
+//   1. Bumps patch, builds, packs, pushes (FinalPushLocalPackages).
+//   2. Clones the cluster's Active configuration into a new Draft with bumped
+//      minor version and the packages list refreshed from the live nuget feed.
+//   3. configurations_check -> setReady -> migrationCreate.
+//   4. Walks the migration: per-template forward resource updates, node
+//      updates to Destination, manual restarts for min-pinned stragglers,
+//      migrationFinish.
+//   5. Verifies the new configuration is Active, the previous is Archived,
+//      no isObsolete nodes remain.
+//
+// Defaults expect the parameterised local devcluster on http://localhost:28080
+// with admin/admin against KlusterKite.NodeManager.WebApplication. Override
+// with --api/--user/--password/--client-id or env KK_API_URL/KK_USER/
+// KK_PASSWORD/KK_CLIENT_ID.
+//
+// Usage:
+//   dotnet cake build.cake --target=LocalDevClusterUpdate --notes="..."
+//   dotnet cake build.cake --target=LocalDevClusterUpdate --notes="..." --bump=major
+//   dotnet cake build.cake --target=LocalDevClusterUpdate --name="Release 0.4" --notes="..."
+//
+// --notes is optional but strongly recommended (and required when an agent
+// drives the upgrade): the Configuration's notes field is the only readable
+// audit trail of what each migration changed.
+
+string _kkApi;
+string _kkToken;
+HttpClient _kkHttp;
+
+HttpClient KkHttp()
+{
+    if (_kkHttp == null)
+    {
+        _kkHttp = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
+    }
+    return _kkHttp;
+}
+
+void KkAuth(string user, string password, string clientId)
+{
+    var url = $"{_kkApi}/api/1.x/security/token";
+    var form = $"grant_type=password&username={Uri.EscapeDataString(user)}"
+             + $"&password={Uri.EscapeDataString(password)}"
+             + $"&client_id={Uri.EscapeDataString(clientId)}";
+    var req = new HttpRequestMessage(HttpMethod.Post, url)
+    {
+        Content = new StringContent(form, System.Text.Encoding.UTF8, "application/x-www-form-urlencoded"),
+    };
+    var resp = KkHttp().SendAsync(req).GetAwaiter().GetResult();
+    var text = resp.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+    if (!resp.IsSuccessStatusCode)
+    {
+        throw new Exception($"auth failed ({(int)resp.StatusCode}): {text}");
+    }
+    _kkToken = JsonNode.Parse(text)["access_token"].GetValue<string>();
+}
+
+JsonNode KkGql(string query, JsonNode variables = null, bool expectErrorsInPayload = false)
+{
+    // The cluster's own nginx returns 404/502/503 during NodesUpdating while
+    // upstreams drop and reattach. Treat those (plus IO/timeout exceptions)
+    // as transient and retry with backoff.
+    var payload = new JsonObject { ["query"] = query };
+    if (variables != null)
+    {
+        payload["variables"] = variables;
+    }
+    var json = payload.ToJsonString();
+    int attempt = 0;
+    const int maxAttempts = 12;
+    Exception last = null;
+    while (attempt++ < maxAttempts)
+    {
+        try
+        {
+            var req = new HttpRequestMessage(HttpMethod.Post, $"{_kkApi}/api/1.x/graphQL")
+            {
+                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json"),
+            };
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _kkToken);
+            var resp = KkHttp().SendAsync(req).GetAwaiter().GetResult();
+            var text = resp.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            if (!resp.IsSuccessStatusCode)
+            {
+                int code = (int)resp.StatusCode;
+                if (code == 404 || code == 502 || code == 503 || code == 504)
+                {
+                    last = new Exception($"graphql {code}: {text.Substring(0, Math.Min(text.Length, 200))}");
+                    Verbose($"  graphql transient {code} (attempt {attempt}/{maxAttempts}), retrying");
+                    System.Threading.Thread.Sleep(Math.Min(15000, 2000 * attempt));
+                    continue;
+                }
+                throw new Exception($"graphql {code}: {text.Substring(0, Math.Min(text.Length, 400))}");
+            }
+            var body = JsonNode.Parse(text);
+            if (!expectErrorsInPayload && body["errors"] != null)
+            {
+                throw new Exception($"graphql errors: {body["errors"].ToJsonString()}");
+            }
+            return body;
+        }
+        catch (HttpRequestException ex)
+        {
+            last = ex;
+            Verbose($"  graphql IO error (attempt {attempt}/{maxAttempts}): {ex.Message}; retrying");
+            System.Threading.Thread.Sleep(Math.Min(15000, 2000 * attempt));
+        }
+        catch (TaskCanceledException ex)
+        {
+            last = ex;
+            Verbose($"  graphql timeout (attempt {attempt}/{maxAttempts}); retrying");
+            System.Threading.Thread.Sleep(Math.Min(15000, 2000 * attempt));
+        }
+    }
+    throw new Exception($"graphql failed after {maxAttempts} attempts: {last?.Message}");
+}
+
+void KkCheckPayloadErrors(JsonNode payload, string label)
+{
+    if (payload == null)
+    {
+        throw new Exception($"{label}: null payload");
+    }
+    var edges = payload["errors"]?["edges"] as JsonArray;
+    if (edges != null && edges.Count > 0)
+    {
+        throw new Exception($"{label} failed: {payload["errors"].ToJsonString()}");
+    }
+}
+
+JsonNode KkActiveConfig()
+{
+    var body = KkGql(@"{
+      api { klusterKiteNodesApi { configurations(filter:{state:Active},limit:1){
+        edges{node{
+          _id name majorVersion minorVersion notes
+          settings{
+            nugetFeed
+            seedAddresses
+            packages{ edges{ node{ _id version } } }
+            nodeTemplates{ edges{ node{
+              code name notes
+              minimumRequiredInstances maximumNeededInstances
+              priority containerTypes configuration
+              packageRequirements{ edges{ node{ _id specificVersion } } }
+            }}}
+            migratorTemplates{ edges{ node{
+              code name notes priority configuration
+              packageRequirements{ edges{ node{ _id specificVersion } } }
+            }}}
+          }
+        }}
+      }}}
+    }");
+    var edges = body["data"]["api"]["klusterKiteNodesApi"]["configurations"]["edges"] as JsonArray;
+    if (edges == null || edges.Count == 0)
+    {
+        throw new Exception("no Active configuration found on the cluster");
+    }
+    return edges[0]["node"].DeepClone();
+}
+
+JsonArray KkLatestPackages()
+{
+    var body = KkGql(@"{
+      api { klusterKiteNodesApi { nugetPackages{ edges{ node{ name version } } } } }
+    }");
+    var src = body["data"]["api"]["klusterKiteNodesApi"]["nugetPackages"]["edges"] as JsonArray;
+    var arr = new JsonArray();
+    foreach (var e in src)
+    {
+        arr.Add(new JsonObject
+        {
+            ["id"] = e["node"]["name"].GetValue<string>(),
+            ["version"] = e["node"]["version"].GetValue<string>(),
+        });
+    }
+    return arr;
+}
+
+JsonArray KkPackageRequirements(JsonNode template)
+{
+    var arr = new JsonArray();
+    var edges = template["packageRequirements"]?["edges"] as JsonArray;
+    if (edges == null) return arr;
+    foreach (var e in edges)
+    {
+        arr.Add(new JsonObject
+        {
+            ["id"] = e["node"]["_id"].GetValue<string>(),
+            ["specificVersion"] = e["node"]["specificVersion"]?.DeepClone(),
+        });
+    }
+    return arr;
+}
+
+JsonObject KkBuildSettings(JsonNode active, JsonArray packages)
+{
+    var s = active["settings"];
+    var nodeTemplates = new JsonArray();
+    foreach (var e in (s["nodeTemplates"]["edges"] as JsonArray))
+    {
+        var t = e["node"];
+        nodeTemplates.Add(new JsonObject
+        {
+            ["code"] = t["code"]?.DeepClone(),
+            ["name"] = t["name"]?.DeepClone(),
+            ["notes"] = t["notes"]?.DeepClone(),
+            ["minimumRequiredInstances"] = t["minimumRequiredInstances"]?.DeepClone(),
+            ["maximumNeededInstances"] = t["maximumNeededInstances"]?.DeepClone(),
+            ["priority"] = t["priority"]?.DeepClone(),
+            ["containerTypes"] = t["containerTypes"]?.DeepClone(),
+            ["configuration"] = t["configuration"]?.DeepClone(),
+            ["packageRequirements"] = KkPackageRequirements(t),
+        });
+    }
+    var migratorTemplates = new JsonArray();
+    foreach (var e in (s["migratorTemplates"]["edges"] as JsonArray))
+    {
+        var t = e["node"];
+        migratorTemplates.Add(new JsonObject
+        {
+            ["code"] = t["code"]?.DeepClone(),
+            ["name"] = t["name"]?.DeepClone(),
+            ["notes"] = t["notes"]?.DeepClone(),
+            ["priority"] = t["priority"]?.DeepClone(),
+            ["configuration"] = t["configuration"]?.DeepClone(),
+            ["packageRequirements"] = KkPackageRequirements(t),
+        });
+    }
+    return new JsonObject
+    {
+        ["nugetFeed"] = s["nugetFeed"]?.DeepClone(),
+        ["seedAddresses"] = s["seedAddresses"]?.DeepClone(),
+        ["packages"] = packages,
+        ["nodeTemplates"] = nodeTemplates,
+        ["migratorTemplates"] = migratorTemplates,
+    };
+}
+
+int KkCreateDraft(int major, int minor, string name, string notes)
+{
+    var body = KkGql(
+        @"mutation($major:Int!,$minor:Int!,$name:String!,$notes:String!){
+          klusterKiteNodeApi_klusterKiteNodesApi_configurations_create(input:{
+            newNode:{majorVersion:$major,minorVersion:$minor,name:$name,notes:$notes},
+            clientMutationId:""LocalDevClusterUpdate""
+          }){ node{ _id } errors{ edges{ node{ field message } } } }
+        }",
+        new JsonObject
+        {
+            ["major"] = major,
+            ["minor"] = minor,
+            ["name"] = name,
+            ["notes"] = notes ?? "",
+        },
+        expectErrorsInPayload: true);
+    var payload = body["data"]["klusterKiteNodeApi_klusterKiteNodesApi_configurations_create"];
+    KkCheckPayloadErrors(payload, "create");
+    return payload["node"]["_id"].GetValue<int>();
+}
+
+void KkWriteSettings(int id, JsonNode settings, int major, int minor, string name, string notes)
+{
+    // Send via typed variable so GraphQL.NET coerces Float/Bool into the
+    // backing non-nullable .NET value types (priority:double, forceUpdate:bool)
+    // — an inline `priority:1.0` literal trips the resolver with an ARGUMENT error.
+    var newNode = new JsonObject
+    {
+        ["id"] = id,
+        ["majorVersion"] = major,
+        ["minorVersion"] = minor,
+        ["name"] = name,
+        ["notes"] = notes ?? "",
+        ["settings"] = settings,
+    };
+    var body = KkGql(
+        @"mutation($id:Int!,$newNode:KlusterKiteNodeApi_Configuration_Input!){
+          klusterKiteNodeApi_klusterKiteNodesApi_configurations_update(input:{
+            id:$id, newNode:$newNode, clientMutationId:""LocalDevClusterUpdate""
+          }){ node{ _id } errors{ edges{ node{ field message } } } }
+        }",
+        new JsonObject { ["id"] = id, ["newNode"] = newNode },
+        expectErrorsInPayload: true);
+    KkCheckPayloadErrors(
+        body["data"]["klusterKiteNodeApi_klusterKiteNodesApi_configurations_update"],
+        "update");
+}
+
+void KkConfigCheck(int id)
+{
+    var body = KkGql(
+        $@"mutation{{ klusterKiteNodeApi_klusterKiteNodesApi_configurations_check(input:{{
+            id:{id}, clientMutationId:""LocalDevClusterUpdate""
+          }}){{ errors{{ edges{{ node{{ field message }} }} }} }} }}",
+        expectErrorsInPayload: true);
+    KkCheckPayloadErrors(
+        body["data"]["klusterKiteNodeApi_klusterKiteNodesApi_configurations_check"],
+        "check");
+}
+
+void KkSetReady(int id)
+{
+    var body = KkGql(
+        $@"mutation{{ klusterKiteNodeApi_klusterKiteNodesApi_configurations_setReady(input:{{
+            id:{id}, clientMutationId:""LocalDevClusterUpdate""
+          }}){{ errors{{ edges{{ node{{ field message }} }} }} }} }}",
+        expectErrorsInPayload: true);
+    KkCheckPayloadErrors(
+        body["data"]["klusterKiteNodeApi_klusterKiteNodesApi_configurations_setReady"],
+        "setReady");
+}
+
+void KkMigrationCreate(int id)
+{
+    var body = KkGql(
+        $@"mutation{{ klusterKiteNodeApi_klusterKiteNodesApi_clusterManagement_migrationCreate(input:{{
+            newConfigurationId:{id}, clientMutationId:""LocalDevClusterUpdate""
+          }}){{ result{{ errors{{ edges{{ node{{ field message }} }} }} }} }} }}",
+        expectErrorsInPayload: true);
+    var inner = body["data"]["klusterKiteNodeApi_klusterKiteNodesApi_clusterManagement_migrationCreate"]?["result"];
+    KkCheckPayloadErrors(inner, "migrationCreate");
+}
+
+void KkMigrationFinish()
+{
+    KkGql(@"mutation{ klusterKiteNodeApi_klusterKiteNodesApi_clusterManagement_migrationFinish(input:{
+              clientMutationId:""LocalDevClusterUpdate""
+            }){ result } }");
+}
+
+void KkMigrationNodesUpdate(string target)
+{
+    KkGql(
+        $@"mutation{{ klusterKiteNodeApi_klusterKiteNodesApi_clusterManagement_migrationNodesUpdate(input:{{
+              target:{target}, clientMutationId:""LocalDevClusterUpdate""
+            }}){{ result }} }}");
+}
+
+void KkMigrationResourceUpdate(JsonArray resources)
+{
+    var body = KkGql(
+        @"mutation($req:KlusterKiteNodeApi_ResourceUpgradeRequest_Input!){
+            klusterKiteNodeApi_klusterKiteNodesApi_clusterManagement_migrationResourceUpdate(input:{
+              request:$req, clientMutationId:""LocalDevClusterUpdate""
+            }){ result }
+          }",
+        new JsonObject { ["req"] = new JsonObject { ["resources"] = resources } });
+}
+
+void KkUpgradeNode(string address)
+{
+    KkGql(
+        $@"mutation{{ klusterKiteNodeApi_klusterKiteNodesApi_upgradeNode(input:{{
+            address:{System.Text.Json.JsonSerializer.Serialize(address)},
+            clientMutationId:""LocalDevClusterUpdate""
+          }}){{ result{{ result }} }} }}");
+}
+
+JsonNode KkMigrationState()
+{
+    var body = KkGql(@"{
+      api { klusterKiteNodesApi { clusterManagement {
+        currentMigration { state fromConfiguration{_id name} toConfiguration{_id name} }
+        resourceState {
+          currentMigrationStep
+          canCancelMigration canFinishMigration canMigrateResources
+          canUpdateNodesToDestination canUpdateNodesToSource
+          operationIsInProgress
+          migrationState{ templateStates{ edges{ node{
+            code
+            migrators{ edges{ node{
+              typeName direction
+              resources{ edges{ node{ code position migrationToDestinationExecutor migrationToSourceExecutor key } } }
+            }}}
+          }}}}
+          migratableResources: migrationState{ migratableResources{ edges{ node{ key } } } }
+        }
+      }}}
+    }");
+    return body["data"]["api"]["klusterKiteNodesApi"]["clusterManagement"];
+}
+
+JsonArray KkActiveNodes()
+{
+    var body = KkGql(@"{
+      api { klusterKiteNodesApi { getActiveNodeDescriptions { edges { node {
+        nodeId nodeTemplate isObsolete isInitialized
+        nodeAddress { asString }
+      }}}}}
+    }");
+    return body["data"]["api"]["klusterKiteNodesApi"]["getActiveNodeDescriptions"]["edges"] as JsonArray;
+}
+
+JsonArray KkCollectForwardResources(JsonNode state)
+{
+    var rs = state["resourceState"];
+    var ts = rs?["migrationState"]?["templateStates"]?["edges"] as JsonArray;
+    var migratableEdges = rs?["migratableResources"]?["migratableResources"]?["edges"] as JsonArray;
+    var keys = new HashSet<string>();
+    if (migratableEdges != null)
+    {
+        foreach (var e in migratableEdges)
+        {
+            keys.Add(e["node"]["key"].GetValue<string>());
+        }
+    }
+    var output = new JsonArray();
+    if (ts == null) return output;
+    foreach (var t in ts)
+    {
+        var tnode = t["node"];
+        var tcode = tnode["code"].GetValue<string>();
+        foreach (var m in (tnode["migrators"]?["edges"] as JsonArray) ?? new JsonArray())
+        {
+            var mnode = m["node"];
+            var typeName = mnode["typeName"].GetValue<string>();
+            foreach (var r in (mnode["resources"]?["edges"] as JsonArray) ?? new JsonArray())
+            {
+                var rn = r["node"];
+                if (rn["position"]?.GetValue<string>() == "Destination") continue;
+                if (rn["migrationToDestinationExecutor"] is null
+                    || rn["migrationToDestinationExecutor"] is JsonValue jv && jv.TryGetValue<object>(out var ov) && ov == null)
+                {
+                    if (rn["migrationToDestinationExecutor"] == null) continue;
+                }
+                if (rn["migrationToDestinationExecutor"] == null) continue;
+                if (!keys.Contains(rn["key"].GetValue<string>())) continue;
+                output.Add(new JsonObject
+                {
+                    ["templateCode"] = tcode,
+                    ["migratorTypeName"] = typeName,
+                    ["resourceCode"] = rn["code"].GetValue<string>(),
+                    ["target"] = "Destination",
+                });
+            }
+        }
+    }
+    return output;
+}
+
+void KkWaitUntil(Func<JsonNode, bool> predicate, string label, int timeoutSec, int intervalSec = 5)
+{
+    var start = DateTime.UtcNow;
+    var lastReport = DateTime.MinValue;
+    while (true)
+    {
+        var state = KkMigrationState();
+        if (predicate(state)) return;
+        var elapsed = (DateTime.UtcNow - start).TotalSeconds;
+        if (elapsed > timeoutSec)
+        {
+            throw new Exception($"timeout {timeoutSec}s waiting for: {label}");
+        }
+        if ((DateTime.UtcNow - lastReport).TotalSeconds >= 30)
+        {
+            var step = state["resourceState"]?["currentMigrationStep"]?.GetValue<string>() ?? "(none)";
+            var op = state["resourceState"]?["operationIsInProgress"]?.GetValue<bool>() ?? false;
+            var migState = state["currentMigration"]?["state"]?.GetValue<string>() ?? "(none)";
+            Information($"  [{(int)elapsed,4}s] migration={migState} step={step} op_in_progress={op}");
+            lastReport = DateTime.UtcNow;
+        }
+        System.Threading.Thread.Sleep(intervalSec * 1000);
+    }
+}
+
+bool KkCycleObsoleteStragglers(int timeoutSec)
+{
+    var nodes = KkActiveNodes();
+    var obsolete = new List<string>();
+    var templates = new Dictionary<string, string>();
+    foreach (var n in nodes)
+    {
+        if (n["node"]["isObsolete"]?.GetValue<bool>() == true)
+        {
+            var addr = n["node"]["nodeAddress"]["asString"].GetValue<string>();
+            obsolete.Add(addr);
+            templates[addr] = n["node"]["nodeTemplate"]?.GetValue<string>() ?? "?";
+        }
+    }
+    if (obsolete.Count == 0) return false;
+    Information($"  found {obsolete.Count} obsolete node(s) the migration won't auto-cycle (min-instance pin); restarting:");
+    foreach (var addr in obsolete)
+    {
+        Information($"    upgradeNode({addr})  [template={templates[addr]}]");
+        KkUpgradeNode(addr);
+    }
+    var seen = new HashSet<string>(obsolete);
+    var start = DateTime.UtcNow;
+    while (true)
+    {
+        var ns = KkActiveNodes();
+        var stillObsolete = 0;
+        var stillOldAddr = 0;
+        foreach (var n in ns)
+        {
+            if (n["node"]["isObsolete"]?.GetValue<bool>() == true) stillObsolete++;
+            if (seen.Contains(n["node"]["nodeAddress"]["asString"].GetValue<string>())) stillOldAddr++;
+        }
+        if (stillObsolete == 0 && stillOldAddr == 0)
+        {
+            Information($"  obsolete stragglers cycled in {(int)(DateTime.UtcNow - start).TotalSeconds}s");
+            return true;
+        }
+        if ((DateTime.UtcNow - start).TotalSeconds > timeoutSec)
+        {
+            throw new Exception(
+                $"timeout {timeoutSec}s cycling obsolete nodes (still obsolete: {stillObsolete}, still on old address: {stillOldAddr})");
+        }
+        System.Threading.Thread.Sleep(10000);
+    }
+}
+
+void KkVerifyActiveAndArchived(int newId, int prevActiveId, int timeoutSec)
+{
+    KkWaitUntil(
+        s => s["currentMigration"] is null
+             || s["currentMigration"] is JsonValue jv && jv.TryGetValue<object>(out var ov) && ov == null,
+        "currentMigration to clear",
+        timeoutSec);
+
+    var body = KkGql($@"{{api{{klusterKiteNodesApi{{
+        configurations(filter:{{state:Active}},limit:1){{edges{{node{{_id name state}}}}}}
+        archived:configurations(filter:{{id:{prevActiveId}}}){{edges{{node{{_id state}}}}}}
+        getActiveNodeDescriptions{{edges{{node{{isObsolete nodeTemplate}}}}}}
+    }}}}}}");
+    var activeEdges = body["data"]["api"]["klusterKiteNodesApi"]["configurations"]["edges"] as JsonArray;
+    if (activeEdges == null || activeEdges.Count == 0)
+    {
+        throw new Exception("no Active configuration after migrationFinish");
+    }
+    var activeId = activeEdges[0]["node"]["_id"].GetValue<int>();
+    if (activeId != newId)
+    {
+        throw new Exception($"expected #{newId} Active, got #{activeId}");
+    }
+    var prevEdges = body["data"]["api"]["klusterKiteNodesApi"]["archived"]["edges"] as JsonArray;
+    if (prevEdges == null || prevEdges.Count == 0
+        || prevEdges[0]["node"]["state"].GetValue<string>() != "Archived")
+    {
+        Warning($"  previous Active #{prevActiveId} did not transition to Archived");
+    }
+    var nodeEdges = body["data"]["api"]["klusterKiteNodesApi"]["getActiveNodeDescriptions"]["edges"] as JsonArray;
+    var stillObsolete = 0;
+    foreach (var n in nodeEdges)
+    {
+        if (n["node"]["isObsolete"]?.GetValue<bool>() == true) stillObsolete++;
+    }
+    if (stillObsolete > 0)
+    {
+        throw new Exception($"{stillObsolete} obsolete node(s) still present after finish");
+    }
+}
+
+Task("LocalDevClusterUpdate")
+    .IsDependentOn("FinalPushLocalPackages")
+    .Does(() =>
+{
+    _kkApi = (Argument("api", EnvironmentVariable("KK_API_URL") ?? "http://localhost:28080")).TrimEnd('/');
+    var user = Argument("user", EnvironmentVariable("KK_USER") ?? "admin");
+    var password = Argument("password", EnvironmentVariable("KK_PASSWORD") ?? "admin");
+    var clientId = Argument("client-id", EnvironmentVariable("KK_CLIENT_ID") ?? "KlusterKite.NodeManager.WebApplication");
+    var notes = Argument("notes", "");
+    var defaultName = $"Release {DateTime.UtcNow:yyyyMMddHHmmss}";
+    var name = Argument("name", defaultName);
+    var bump = Argument("bump", "minor");
+    var timeoutSec = Argument("timeout", 900);
+
+    Information($"=== LocalDevClusterUpdate against {_kkApi} ===");
+    KkAuth(user, password, clientId);
+    Information("auth ok");
+
+    var active = KkActiveConfig();
+    var activeId = active["_id"].GetValue<int>();
+    var activeMajor = active["majorVersion"].GetValue<int>();
+    var activeMinor = active["minorVersion"].GetValue<int>();
+    Information($"active: #{activeId} '{active["name"].GetValue<string>()}' v{activeMajor}.{activeMinor}");
+
+    int newMajor = activeMajor;
+    int newMinor = activeMinor;
+    if (bump == "major") { newMajor++; newMinor = 0; }
+    else if (bump == "minor") { newMinor++; }
+    else if (bump == "none") { /* keep */ }
+    else { throw new Exception($"unknown bump: {bump} (expected major|minor|none)"); }
+
+    var packages = KkLatestPackages();
+    Information($"latest packages on feed: {packages.Count}");
+    var settings = KkBuildSettings(active, packages);
+
+    var newId = KkCreateDraft(newMajor, newMinor, name, notes);
+    Information($"created draft #{newId}");
+    KkWriteSettings(newId, settings, newMajor, newMinor, name, notes);
+    Information("settings written");
+    KkConfigCheck(newId);
+    Information("check ok");
+    KkSetReady(newId);
+    Information($"#{newId} -> Ready");
+
+    KkMigrationCreate(newId);
+    Information($"migration started -> #{newId}");
+
+    var deadline = DateTime.UtcNow.AddSeconds(timeoutSec);
+    while (true)
+    {
+        if (DateTime.UtcNow > deadline)
+        {
+            throw new Exception("migration walk timed out");
+        }
+        var state = KkMigrationState();
+        var migration = state["currentMigration"];
+        if (migration == null
+            || (migration is JsonValue mv && mv.TryGetValue<object>(out var mvv) && mvv == null))
+        {
+            Information("currentMigration cleared without a Finish call; verifying state");
+            break;
+        }
+        var rs = state["resourceState"];
+        var step = rs?["currentMigrationStep"]?.GetValue<string>();
+        var canFinish = rs?["canFinishMigration"]?.GetValue<bool>() == true;
+        var canUpdateNodes = rs?["canUpdateNodesToDestination"]?.GetValue<bool>() == true;
+
+        var resources = KkCollectForwardResources(state);
+        if (resources.Count > 0)
+        {
+            Information($"  step={step}: migrating {resources.Count} resource(s) to Destination");
+            KkMigrationResourceUpdate(resources);
+            KkWaitUntil(
+                s => !(s["resourceState"]?["operationIsInProgress"]?.GetValue<bool>() ?? false),
+                "resource migration to settle",
+                timeoutSec);
+            continue;
+        }
+
+        if (canUpdateNodes)
+        {
+            Information($"  step={step}: updating nodes to Destination");
+            KkMigrationNodesUpdate("Destination");
+            KkWaitUntil(
+                s => (s["resourceState"]?["currentMigrationStep"]?.GetValue<string>() ?? "") != "NodesUpdating"
+                     && !(s["resourceState"]?["operationIsInProgress"]?.GetValue<bool>() ?? false),
+                "nodes update to settle",
+                timeoutSec, intervalSec: 10);
+            KkCycleObsoleteStragglers(timeoutSec);
+            continue;
+        }
+
+        if (KkCycleObsoleteStragglers(timeoutSec)) continue;
+
+        if (canFinish)
+        {
+            Information("issuing migrationFinish");
+            KkMigrationFinish();
+            break;
+        }
+
+        // Nothing actionable; idle a bit and recheck
+        System.Threading.Thread.Sleep(5000);
+    }
+
+    KkVerifyActiveAndArchived(newId, activeId, timeoutSec);
+    Information($"LocalDevClusterUpdate complete. Active is now #{newId} '{name}'.");
 });
 
 // Entry point


### PR DESCRIPTION
## Summary

Wraps the full local-devcluster refresh flow into a single Cake target — `LocalDevClusterUpdate` — that bumps the patch, builds, packs, pushes, then drives a Configuration migration through the cluster's GraphQL API end-to-end. Replaces the manual API-by-hand flow that required juggling multiple curl commands and was non-deterministic when the cluster's own nginx returned transient 404s during `NodesUpdating`.

```bash
NUGET_API_KEY=KlusterKite NUGET_SERVER_URL=http://localhost:28081 \
  dotnet cake build.cake --target=LocalDevClusterUpdate --notes="..."
```

What the target does:

1. `FinalPushLocalPackages` — `SetVersion` auto-bumps the patch (`0.0.5-local` → `0.0.6-local`), `Clean` → `PrepareSources` → `Build` → `Nuget` → `PushLocalPackages`.
2. Authenticates against `/api/1.x/security/token` (`admin`/`admin` / `KlusterKite.NodeManager.WebApplication` defaults; override via `--user`/`--password`/`--client-id` or env `KK_USER`/`KK_PASSWORD`/`KK_CLIENT_ID`).
3. Reads the Active `Configuration`, queries `nugetPackages` for the latest versions on the local feed, and clones the Active settings into a new `Draft` with the minor version bumped (`--bump=minor` default; `major` and `none` also accepted) and the `packages` list refreshed.
4. `configurations_check` → `setReady` → `migrationCreate`.
5. Walks the migration: per-template forward `migrationResourceUpdate`, `migrationNodesUpdate(Destination)`, manual `upgradeNode` for any minimum-instance-pinned templates the cluster will not auto-cycle, then `migrationFinish`.
6. Verifies `currentMigration` cleared, the new Configuration is `Active`, the previous one `Archived`, and zero `isObsolete: true` nodes remain.

## Implementation notes

- **Settings travel as a typed GraphQL variable, never inline.** GraphQL.NET rejects `priority:1.0` (Float → non-nullable `double`) and `forceUpdate:false` (Bool → non-nullable `bool`) with a generic `ARGUMENT` error when they come from an inline literal — the same payload as a JSON variable coerces cleanly.
- **Each mutation selects only fields present on its actual payload type.** `Configuration_NodeMutationPayload` exposes `node`/`edge`/`errors`/`deletedId` but no `result`; `Boolean_MutationPayload` exposes only `result`; `MutationResult_*MutationPayload` nests its errors under an inner `result{ errors{...} }`.
- **`KkGql` retries 404/502/503/504 + IO/timeout errors with capped backoff.** During the `NodesUpdating` step the cluster's own nginx briefly drops upstreams and returns 404; without this, polling intermittently kills the migration walk even though the cluster itself is healthy.
- **Min-instance-pinned `NodeTemplates`** (`minimumRequiredInstances == maximumNeededInstances`) are not cycled by the cluster's automatic node-update because dropping the only running instance would breach the floor. The target scans `getActiveNodeDescriptions`, calls `upgradeNode(address)` on each `isObsolete: true` node (the same call as the per-node Reset button on the home page), and waits for the launchers to drop their old address before proceeding.

## Skill cleanup

`.claude/skills/cluster-upgrade/SKILL.md` is rewritten as a short pointer to the new target, plus the cold-start, debug-shortcut, decision quick-reference, manual-API surface, and pitfalls sections that still apply for the narrow cases where the target is not the right tool. The previous Python orchestrator (`upgrade.py`) is deleted — the target supersedes it entirely.

## Test plan

- [x] `dotnet cake build.cake --target=LocalDevClusterUpdate --dryrun` shows the expected task graph (`Clean → SetVersion → PrepareSources → Build → Nuget → PushLocalPackages → FinalPushLocalPackages → LocalDevClusterUpdate`).
- [x] End-to-end run against a live local devcluster: `Release 0.2` → `Release 0.3` → `Release 0.4`. Each migration leaves `currentMigration: null`, the new Configuration `Active`, the previous `Archived`, and no obsolete nodes.
- [x] Retry logic verified: a run that hit transient 404s during `NodesUpdating` recovered without operator intervention; the same flow without retry left the migration in a half-finished state requiring a manual `migrationFinish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)